### PR TITLE
input without type attribute

### DIFF
--- a/src/less/form.less
+++ b/src/less/form.less
@@ -39,13 +39,14 @@
 
 /*
  * Controls
- * Exept for `range`, `radio`, `checkbox`, `file`, `submit`, `reset`, `button` and `image`
+ * Except for `range`, `radio`, `checkbox`, `file`, `submit`, `reset`, `button` and `image`
  * 1. Must be `height` because `min-height` is not working in OSX
- * 2. Responsiveness: Sets a maxium width relative to the parent to scale on narrower viewports
+ * 2. Responsiveness: Sets a maximum width relative to the parent to scale on narrower viewports
  */
 
 .uk-form select,
 .uk-form textarea,
+.uk-form input:not([type]),
 .uk-form input[type="text"],
 .uk-form input[type="password"],
 .uk-form input[type="datetime"],
@@ -281,12 +282,12 @@ select.uk-form-width-mini { width: (@form-mini-width + 25px); } /* 1 */
 @media (max-width: @breakpoint-medium-max) {
 
 	.uk-form-horizontal .uk-form-label {
-		
+
 		/* Behave like `uk-form-stacked` */
 		display: block;
 		margin-bottom: 5px;
 		font-weight: bold;
-		
+
 	}
 
 }


### PR DESCRIPTION
Consider `input:not([type])` as `input[type=text]`because browsers behave the same way
And 2 typos fixed.
Fixes #139
