### PR TITLE
Close dropdown by clicking outside of it

### DIFF
--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -83,6 +83,17 @@
 
             }).on("mouseleave", function() {
 
+                setTimeout(function() {
+                    $(document).on("click.outer.dropdown", function(e) {
+
+                        if (active && active[0] == $this.element[0] && ($(e.target).is("a") || !$this.element.find(".uk-dropdown").find(e.target).length)) {
+                            active.removeClass("uk-open");
+
+                            $(document).off("click.outer.dropdown");
+                        }
+                    });
+                }, 10);
+
                 $this.remainIdle = setTimeout(function() {
 
                     $this.element.removeClass("uk-open");


### PR DESCRIPTION
Simple trick, code from click dropdown mode to mouseleave.
This allows to close dropdown faster, before 800 ms has elapsed.
Such behavior is more natural, than current.

This is solution for issue #133, which was closed by misunderstanding I suppose.
