### PR TITLE
Reverting of $.UIkit.tab availability

### DIFF
--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -60,6 +60,8 @@
         this.element.data("tab", this);
     };
 
+    UI["tab"] = Tab;
+
     $(document).on("uk-domready", function(e) {
 
         $("[data-uk-tab]").each(function() {


### PR DESCRIPTION
It was removed here: https://github.com/uikit/uikit/commit/2f8a8b559463f3a8068b3326874827e0ef00e895#diff-ce215d94a52d449f1a34f292126608d7L60

I'm using it to connect connect switcher. But connect by natural position in dom, not by ID.
Example how I use it: https://github.com/nazar-pc/CleverStyle-CMS/blob/b1b9ed3cabd3d19cd66ece24d75575df0f30ca75/includes/js/jquery.cs-helper.coffee#L87

Patch is very simple, I hope you will accept it.
