### PR TITLE
Some overcomplication in tab component

### DIFF
--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -60,14 +60,10 @@
         this.element.data("tab", this);
     };
 
-    $(document).on("uk-domready", function(e) {
+    $(document).on("uk-domready", function() {
 
         $("[data-uk-tab]").each(function() {
-            var tab = $(this);
-
-            if (!tab.data("tab")) {
-                var obj = new Tab(tab, UI.Utils.options(tab.attr("data-uk-tab")));
-            }
+            new Tab(this, UI.Utils.options(this.getAttribute("data-uk-tab")));
         });
     });
 


### PR DESCRIPTION
jQuery collection creation already present in `Tab`, as well as checking for `.data("tab")` presence.
Also, `e` argument is not used in callback and can be removed.
And, obviously, there is no need to save object inside `obj` variable as it will be never used.

Just one line instead of 5, no conditions, no additional variables.

I didn't check other components, but I think such code is much easier to read, understand and maintain.
