### PR TITLE
Rule 'display:table' added to uk-alert

### DIFF
--- a/src/less/alert.less
+++ b/src/less/alert.less
@@ -44,6 +44,7 @@
     padding: @alert-padding;
     background: @alert-background;
     color: @alert-color;
+    display: table;
     .hook-alert;
 }
 


### PR DESCRIPTION
This rule will prevent an aligned element with `uk-align-right` or `uk-align-left` from hiding a `uk-alert` element ([here](http://www.philosophyguides.org/decoding-of-augustinus-confessiones/) is an example of mine, sorry it is in Japanese).
