### PR TITLE
Ability to right align form icons.

### DIFF
--- a/src/less/form.less
+++ b/src/less/form.less
@@ -370,8 +370,11 @@ select.uk-form-width-mini { width: (@form-mini-width + 25px); } /* 1 */
     text-align: center;
 }
 
+.uk-form-icon > .uk-align-icon-right { right: 0; }
+
 .uk-form-icon > input { padding-left: @form-icon-width !important; }
 
+.uk-form-icon > .uk-align-icon-right + input { padding-right: @form-icon-width !important; }
 
 // Hooks
 // ========================================================================


### PR DESCRIPTION
This commit adds the ability to add right aligned form icons.

Example:

```
<div class="uk-form-icon">
    <i class="uk-icon-star"></i>
    <i class="uk-align-icon-right uk-icon-info" data-uk-tooltip="{pos:'right'}" title="Two-factor authentication code"></i>
    <input class="uk-width-1-1" type="text" name="secretkey" tabindex="0" placeholder="Security code" />
</div>
```

This example will show both a left and right aligned form icon.
