### PR TITLE
Explain necessity for a .uk-width-*-* even for single-column layouts

### DIFF
--- a/docs/grid.html
+++ b/docs/grid.html
@@ -189,6 +189,8 @@
     &lt;div class="uk-width-1-2"&gt;...&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 
+			    <p><span class="uk-badge">NOTE</span> A <code>.uk-grid</code> must <em>always</em> have an associated <code>.uk-width-*-*</code>. In the case of a single-column layout simply use <code>.uk-width-1-1</code>...</p>
+
                             <hr class="uk-article-divider">
 
                             <h2>Responsive width</h2>


### PR DESCRIPTION
The suggested edit comes from this question: https://github.com/uikit/uikit/issues/180
I did not realize a `.uk-width-*-*` was always required.
Other beginners might stumble on this as well...
