### PR TITLE
Add link to searchresults.json example

### DIFF
--- a/docs/search.html
+++ b/docs/search.html
@@ -154,7 +154,7 @@
 
                             <h2>Ajax search results</h2>
 
-                            <p>You can use a dropdown from the <a href="dropdown.html">Dropdown component</a> to display search results. Just add <code>{source:'PATH/TO/RESULTS'}</code> to the data attribute and set the path to your search results, which need to be formatted in JSON. This enables the Ajax search and injects a dropdown with the <code>.uk-dropdown-search</code> class displaying the search results. You can even navigate through the dropdown with the up and down keys of your keyboard.</p>
+                            <p>You can use a dropdown from the <a href="dropdown.html">Dropdown component</a> to display search results. Just add <code>{source:'PATH/TO/RESULTS'}</code> to the data attribute and set the path to your search results, which need to be formatted in JSON (example <a href="../vendor/searchresults.json">here</a>). This enables the Ajax search and injects a dropdown with the <code>.uk-dropdown-search</code> class displaying the search results. You can even navigate through the dropdown with the up and down keys of your keyboard.</p>
 
                             <h3 class="tm-article-subtitle">Example</h3>
 


### PR DESCRIPTION
The docs don't show an example of what the Ajax search results should look like, as stated in #200.
