### PR TITLE
Workaround for Firefox 26 TouchEvent exposition

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -52,7 +52,7 @@
     })();
 
     UI.support.requestAnimationFrame = global.requestAnimationFrame || global.webkitRequestAnimationFrame || global.mozRequestAnimationFrame || global.msRequestAnimationFrame || global.oRequestAnimationFrame || function(callback){ global.setTimeout(callback, 1000/60); };
-    UI.support.touch                 = (('ontouchstart' in window && new RegExp(/Mobi/).test(document.userAgent)) || (global.DocumentTouch && document instanceof global.DocumentTouch)  || (global.navigator['msPointerEnabled'] && global.navigator['msMaxTouchPoints'] > 0) || false);
+    UI.support.touch                 = (('ontouchstart' in window && new RegExp(/Mobi|Tablet/).test(document.userAgent)) || (global.DocumentTouch && document instanceof global.DocumentTouch)  || (global.navigator['msPointerEnabled'] && global.navigator['msMaxTouchPoints'] > 0) || false);
     UI.support.mutationobserver      = (global.MutationObserver || global.WebKitMutationObserver || global.MozMutationObserver || null);
 
     UI.Utils = {};


### PR DESCRIPTION
Firefox expose a Touch event event on desktop. This is a quick fix. Every  mobile browser contains a string with at least 'Mobi'; Firefox add 'Tablet' on tablets.

see:
https://developer.mozilla.org/en-US/docs/Browser_detection_using_the_user_agent#Mobile.2C_Tablet_or_Desktop
