### PR TITLE
Use pointer cursor for form labels

### DIFF
--- a/src/less/form.less
+++ b/src/less/form.less
@@ -172,9 +172,7 @@
  * Label style
  */
 
-.uk-form label {
-    cursor: pointer;
-}
+.uk-form label[for] { cursor: pointer; }
 
 /* Size modifiers
  * Using !important to keep the selector simple


### PR DESCRIPTION
I think form labels should use cursor pointers since they are clickable.
