### PR TITLE
Add translation capabilites and french translation

### DIFF
--- a/addons/src/datepicker/datepicker.js
+++ b/addons/src/datepicker/datepicker.js
@@ -42,12 +42,21 @@
 
         this.element.data("datepicker", this);
     };
+    var language = (navigator.language || navigator.browserLanguage || navigator.userLanguage).substr(0,2) || 'en',
+        MONTHS = {
+            'en': ['January','February','March','April','May','June','July','August','September','October','November','December'],
+            'fr': ['janvier', 'f&eacute;vrier', 'mars', 'avril', 'mai', 'juin', 'juillet', 'ao&ucirc;t', 'septembre', 'octobre', 'novembre', 'd&eacute;cembre']
+        },
+        WEEKDAYS = {
+            'en': ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],
+            'fr': ['Dim','Lun','Mar','Mer','Jeu','Ven','Sam']
+        };
 
     DatePicker.defaults = {
         weekstart: 1,
         i18n: {
-            months        : ['January','February','March','April','May','June','July','August','September','October','November','December'],
-            weekdays      : ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+            months        : MONTHS[language],
+            weekdays      : WEEKDAYS[language]
         },
         format: "DD.MM.YYYY",
         offsettop: 5,


### PR DESCRIPTION
datepicker.js has months and days hard coded.

In french, months first letter isn't a capital letter (it's not a mistake). 

(sorry for the noise. I'm not as fluent as I imagine with Git :| )
