### PR TITLE
Update uikit.css

### DIFF
--- a/dist/css/uikit.css
+++ b/dist/css/uikit.css
@@ -82,6 +82,7 @@ a {
  */
 a:active,
 a:hover {
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   outline: 0;
 }
 /* Text-level semantics


### PR DESCRIPTION
Removed default blue border/background for tappable elements in android.
