### PR TITLE
Added hover delay to dropdown menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### WIP
 
+ - Added hover delay to dropdown menus
  - Added scrollable dropdown class
  - Added month and year picker for datepicker add-on
  - Added support for a handle class parameter in sortable add-on
@@ -13,7 +14,7 @@
  - Fixed js error causing by the sortable add-on
  - Fixed switcher component: document scrolls to top when clicking on a[href='#']
  - Fixed search add-on missing uk-active class
- 
+
 ### 2.7.1 (June 06, 2014)
 
   - Reverted hidden and visibility classes for breakpoint mini

--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -10,10 +10,12 @@
            "mode": "hover",
            "remaintime": 800,
            "justify": false,
-           "boundary": $(window)
+           "boundary": $(window),
+           "delay": 0
         },
 
         remainIdle: false,
+        hoverDelay: false,
 
         init: function() {
 
@@ -67,9 +69,21 @@
                         clearTimeout($this.remainIdle);
                     }
 
-                    $this.show();
+                    if ($this.hoverDelay) {
+                        clearTimeout($this.hoverDelay);
+                    }
+
+                    $this.hoverDelay = setTimeout(function() {
+
+                        $this.show();
+
+                    }, $this.options.delay );
 
                 }).on("mouseleave", function() {
+
+                    if ( $this.hoverDelay ) {
+                        clearTimeout($this.hoverDelay);
+                    }
 
                     $this.remainIdle = setTimeout(function() {
 
@@ -223,7 +237,11 @@
             var dropdown = UI.dropdown(ele, UI.Utils.options(ele.data("uk-dropdown")));
 
             if (triggerevent=="click" || (triggerevent=="mouseenter" && dropdown.options.mode=="hover")) {
-                dropdown.show();
+                dropdown.hoverDelay = setTimeout(function() {
+
+                    dropdown.show();
+
+                }, dropdown.options.delay );
             }
 
             if(dropdown.element.find('.uk-dropdown').length) {


### PR DESCRIPTION
Added optional delay to mouseenter event to prevent drop down menus from
immediately opening as the mouse passes over the button.
