### PR TITLE
Allow operations on XMLHttpRequest before send()

### DIFF
--- a/src/js/addons/upload.js
+++ b/src/js/addons/upload.js
@@ -191,7 +191,7 @@
                     settings.complete(response, xhr);
                 }
             };
-
+			settings.beforesend(xhr);
             xhr.send(formData);
         }
     }
@@ -207,6 +207,7 @@
 
         // events
         'before'          : function(o){},
+		'beforesend'      : function(xhr){},
         'loadstart'       : function(){},
         'load'            : function(){},
         'loadend'         : function(){},


### PR DESCRIPTION
In many case, and in mine with Django for CSRF protection, the upload add-on needs to expose the XMLHttpRequest object.
There's others solutions (such as create a dictionnary in settings) but they are much more complex (and possibly more buggy) to implement. 
