### PR TITLE
Tooltip offset

### DIFF
--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -49,7 +49,7 @@
             $tooltip.html('<div class="uk-tooltip-inner">' + this.tip + '</div>');
 
             var $this      = this,
-                bodyoffset = $('body').offset(),
+                htmlOffset = $('html').offset(),
                 pos        = $.extend({}, this.element.offset(), {width: this.element[0].offsetWidth, height: this.element[0].offsetHeight}),
                 width      = $tooltip[0].offsetWidth,
                 height     = $tooltip[0].offsetHeight,
@@ -65,8 +65,8 @@
 
             // prevent strange position
             // when tooltip is in offcanvas etc.
-            pos.left -= bodyoffset.left;
-            pos.top  -= bodyoffset.top;
+            pos.left -= htmlOffset.left;
+            pos.top  -= htmlOffset.top;
 
             if ((tmppos[0] == "left" || tmppos[0] == "right") && $.UIkit.langdirection == 'right') {
                 tmppos[0] = tmppos[0] == "left" ? "right" : "left";


### PR DESCRIPTION
Should be set to html instead of body for sites that have styles
attributed to html (i.e. WordPress admin toolbar on fronted)
