### PR TITLE
uk-dropdown-scrollable height fix

### DIFF
--- a/src/less/dropdown.less
+++ b/src/less/dropdown.less
@@ -258,7 +258,7 @@
 
 .uk-dropdown-scrollable {
     overflow-y: auto;
-    height: @dropdown-scrollable-height;
+    max-height: @dropdown-scrollable-height;
 }
 
 


### PR DESCRIPTION
- Dropdown should have a max-height, not implicit height set in the event there are not enough dropdown items to warrant the overflow.
