### PR TITLE
Make icon font family and filename variables

### DIFF
--- a/src/less/addons/datepicker.less
+++ b/src/less/addons/datepicker.less
@@ -102,7 +102,7 @@
 .uk-datepicker-previous:after,
 .uk-datepicker-next:after {
     width: @datepicker-nav-height;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 .uk-datepicker-previous:after { content: @datepicker-previous-icon; }

--- a/src/less/addons/form-advanced.less
+++ b/src/less/addons/form-advanced.less
@@ -87,7 +87,7 @@
 /* Checkbox */
 .uk-form input[type=checkbox]:checked:before {
     content: @form-advanced-checkbox-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     font-size: @form-advanced-checkbox-font-size;
     -webkit-font-smoothing: antialiased;
     text-align: center;

--- a/src/less/addons/nestable.less
+++ b/src/less/addons/nestable.less
@@ -126,7 +126,7 @@
 /* Icon */
 .uk-nestable-handle:after {
     content: @nestable-handle-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 
@@ -158,7 +158,7 @@
 /* Icon */
 [data-nestable-action='toggle']:after {
     content: @nestable-toggle-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 /*

--- a/src/less/addons/search.less
+++ b/src/less/addons/search.less
@@ -13,7 +13,7 @@
 //                  `uk-loading`
 //
 // Uses:            Animation
-//                  Icon: FontAwesome
+//                  Icon: Icon Font Family
 //                  Navbar: `uk-navbar-flip`
 //
 // Used by:         Off-canvas
@@ -101,7 +101,7 @@
     width: @search-padding;
     line-height: @search-height;
     text-align: center;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     font-size: @search-icon-size;
     color: @search-icon-color;
     .hook-search-icon;
@@ -192,7 +192,7 @@ input.uk-search-field { -webkit-appearance: none; }
 .uk-search-close:after {
     display: block;
     content: @search-close-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 /* Loading icon */

--- a/src/less/addons/slidenav.less
+++ b/src/less/addons/slidenav.less
@@ -4,11 +4,11 @@
 // Component:       `uk-slidenav`
 //
 // Modifiers:       `uk-slidenav-previous`
-//                  `uk-slidenav-next`  
+//                  `uk-slidenav-next`
 //
 // Sub-objects:     `uk-slidenav-position`
 //
-// Uses:            Icon: FontAwesome
+// Uses:            Icon: Icon Font Family
 //
 // ========================================================================
 
@@ -90,12 +90,12 @@
 
 .uk-slidenav-previous:before {
     content: @slidenav-previous-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 .uk-slidenav-next:before {
     content: @slidenav-next-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 

--- a/src/less/close.less
+++ b/src/less/close.less
@@ -5,7 +5,7 @@
 //
 // Modifiers:       `uk-close-alt`
 //
-// Uses:            Icon: FontAwesome
+// Uses:            Icon: Icon Font Family
 //
 // Used by:         Alert
 //                  Modal
@@ -58,7 +58,7 @@
 .uk-close:after {
     display: block;
     content: "\f00d";
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 /*

--- a/src/less/icon.less
+++ b/src/less/icon.less
@@ -21,6 +21,8 @@
 // ========================================================================
 
 @icon-font-path:                                "../fonts";
+@icon-font-filename:                            "fontawesome-webfont";
+@icon-font-name:                                "FontAwesome";
 
 @icon-small-font-size:                          150%;
 @icon-medium-font-size:                         200%;
@@ -49,11 +51,11 @@
  ========================================================================== */
 
 @font-face {
-    font-family: 'FontAwesome';
-    src: url("@{icon-font-path}/fontawesome-webfont.eot");
-    src: url("@{icon-font-path}/fontawesome-webfont.eot?#iefix") format("embedded-opentype"),
-         url("@{icon-font-path}/fontawesome-webfont.woff") format("woff"),
-         url("@{icon-font-path}/fontawesome-webfont.ttf") format("truetype");
+    font-family: @icon-font-name;
+    src: url("@{icon-font-path}/@{icon-font-filename}.eot");
+    src: url("@{icon-font-path}/@{icon-font-filename}.eot?#iefix") format("embedded-opentype"),
+         url("@{icon-font-path}/@{icon-font-filename}.woff") format("woff"),
+         url("@{icon-font-path}/@{icon-font-filename}.ttf") format("truetype");
     font-weight: normal;
     font-style: normal;
 }
@@ -66,7 +68,7 @@
  */
 
 [class*='uk-icon-'] {
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     /* 1 */
     display: inline-block;
     /* 2 */

--- a/src/less/nav.less
+++ b/src/less/nav.less
@@ -18,7 +18,7 @@
 //                  `uk-open`
 //                  `uk-touch`
 //
-// Uses:            Icon: FontAwesome
+// Uses:            Icon: Icon Font Family
 //
 // Used by:         Panel
 //                  Dropdown
@@ -184,7 +184,7 @@ ul.uk-nav-sub {
     width: @nav-parent-icon-width;
     margin-right: @nav-parent-icon-margin-right;
     float: right;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     text-align: center;
     .hook-nav-parent-icon;
 }

--- a/src/less/navbar.less
+++ b/src/less/navbar.less
@@ -271,7 +271,7 @@
 
 .uk-navbar-toggle:after {
     content: @navbar-toggle-icon;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     /* 1 */
     vertical-align: middle;
 }

--- a/src/less/overlay.less
+++ b/src/less/overlay.less
@@ -116,7 +116,7 @@
     margin-left: -(@overlay-area-icon-size / 2);
     font-size: @overlay-area-icon-size;
     line-height: 1;
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
     text-align: center;
     color: @overlay-area-icon-color;
     .hook-overlay-area-icon;
@@ -218,7 +218,7 @@
 .uk-overlay:hover .uk-overlay-caption,
 .uk-overlay.uk-hover .uk-overlay-caption, // 1
 .uk-overlay-toggle:hover .uk-overlay-caption, // 2
-.uk-overlay-toggle.uk-hover .uk-overlay-caption { opacity: 1; } 
+.uk-overlay-toggle.uk-hover .uk-overlay-caption { opacity: 1; }
 
 
 // Hooks

--- a/src/less/tab.less
+++ b/src/less/tab.less
@@ -156,7 +156,7 @@
 
 .uk-tab-responsive > a:before {
     content: "\f0c9\00a0";
-    font-family: FontAwesome;
+    font-family: @icon-font-name;
 }
 
 /* Phone landscape and smaller */


### PR DESCRIPTION
We shouldn't be relegated to using FontAwesome (or even the naming convention of FontAwesome) for our icon fonts. There's plenty in here that we can override to use different icon fonts, so let's make the icon font itself overridable. Builds on https://github.com/uikit/uikit/pull/555
