### PR TITLE
Sortable.js breaks browser tab shortcuts

### DIFF
--- a/src/js/addons/sortable.js
+++ b/src/js/addons/sortable.js
@@ -65,12 +65,18 @@
             } else {
 
                 // prevent leaving page after link clicking
+                // prevent leaving page after link clicking
                 this.element.on('mousedown touchstart', 'a[href]', function(e) {
-                    clickedlink = $(this);
+                    // don't break browser shortcuts for click+open in new tab
+                    if(!e.ctrlKey && !e.metaKey && !e.shiftKey) {
+                        clickedlink = $(this);
+                    }
                 }).on('click', 'a[href]', function(e) {
-                    clickedlink = $(this);
-                    e.stopImmediatePropagation();
-                    return false;
+                    if(!e.ctrlKey && !e.metaKey && !e.shiftKey) {
+                        clickedlink = $(this);
+                        e.stopImmediatePropagation();
+                        return false;
+                    }
                 });
             }
 


### PR DESCRIPTION
Shortcuts like click+cmd, click+ctrl in browsers that allow opening links in the background is broken.
ctrlKey and metaKey (metaKey is the cmd key on the mac) usually open links in new tabs in the background, Chrome does it like this.
shiftKey in Chrome opens a link in a new window.
