### PR TITLE
filter custom directory for IDE-files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,10 +214,10 @@ module.exports = function(grunt) {
 
                fs.readdirSync('themes/'+f).forEach(function(t){
 
-                   var themepath = 'themes/'+f+'/'+t;
+                   var themepath = 'themes/'+f+'/'+t, exclude = ['blank','.git','.idea'];
 
                    // Is it a directory?
-                   if (fs.lstatSync(themepath).isDirectory() && t!=="blank" && t!=='.git') {
+                   if (fs.lstatSync(themepath).isDirectory() && exclude.indexOf(t) === -1) {
 
                         var theme = {
                             "name"  : t.split("-").join(" ").replace(/^([a-z\u00E0-\u00FC])|\s+([a-z\u00E0-\u00FC])/g, function ($1) { return $1.toUpperCase(); }),


### PR DESCRIPTION
While indexing the theme a theme `.idea` is indexed because of the hidden folder PHPstorm creates there. I expanded the existing filter for `blank` and `.git` with `.idea` and refactored the code so more filters can be added easily later.
Would you consider merging this, so I don;t have to edit the Grunt in a local branch? Thanks
