### PR TITLE
add -a to indexthemes task to index custom themes

### DIFF
--- a/docs/documentation_create-a-theme.html
+++ b/docs/documentation_create-a-theme.html
@@ -87,7 +87,7 @@
 
                             <h3>3. Customizer and Tests</h3>
 
-                            <p>Run the gulp task <code>indexthemes</code> on your UIkit folder. Now the newly created themes will be available automatically in the Customizer and test files.</p>
+                            <p>Run the gulp task <code>indexthemes -a</code> on your UIkit folder. Now the newly created themes will be available automatically in the Customizer and test files.</p>
 
                             <hr class="uk-article-divider">
 


### PR DESCRIPTION
Gulp won't index the custom directory of not -a or -t is passed with the command.
