### PR TITLE
uk-active support for nav dropdown items

### DIFF
--- a/src/less/core/nav.less
+++ b/src/less/core/nav.less
@@ -279,7 +279,8 @@ ul.uk-nav-sub {
  */
 
 .uk-nav-dropdown > li > a:hover,
-.uk-nav-dropdown > li > a:focus { // 1
+.uk-nav-dropdown > li > a:focus,
+.uk-nav-dropdown > li.uk-active > a { // 1
     background: @nav-dropdown-hover-background;
     color: @nav-dropdown-hover-color;
     /* 2 */


### PR DESCRIPTION
Class applied to `li` element, just like in `nav` itself.
This is for #699