### PR TITLE
Fixed input submit button styling

### DIFF
--- a/src/less/core/form.less
+++ b/src/less/core/form.less
@@ -123,7 +123,7 @@
  * 4. Correct `font` properties and `color` not being inherited.
  */
 
-.uk-form input,
+.uk-form input:not([type="submit"]),
 .uk-form select,
 .uk-form textarea {
     /* 1 */


### PR DESCRIPTION
Fixes the styling of `input[type"button"]`, allowing the use of the uikit button classes. Issue #671
