### PR TITLE
Using JSON in lowercase as setting.type for AJAX upload didn't work

### DIFF
--- a/src/js/components/upload.js
+++ b/src/js/components/upload.js
@@ -196,7 +196,7 @@
 
                     var response = xhr.responseText;
 
-                    if (settings.type=="json") {
+                    if ((settings.type).toUpperCase()=="JSON") {
                         try {
                             response = $.parseJSON(response);
                         } catch(e) {


### PR DESCRIPTION
When using the Upload component, by setting "type" to "JSON" instead of "json" it wouldn't work.