### PR TITLE
Nested containers

### DIFF
--- a/src/less/core/utility.less
+++ b/src/less/core/utility.less
@@ -73,6 +73,11 @@
     .hook-container;
 }
 
+/* Allows nested containers */
+.uk-container .uk-container {
+    max-width: 100%;
+}
+
 /* Large screen and bigger */
 @media (min-width: @breakpoint-xlarge) {
 


### PR DESCRIPTION
In modular apps, you might have instances where certain components (bundled with `.uk-container`) end up inside of other parent containers. This PR fixes that use-case to make sure the content does not overflow its parent.