### PR TITLE
Xlarge utility

### DIFF
--- a/docs/utility.html
+++ b/docs/utility.html
@@ -915,7 +915,8 @@
                                             <th class="uk-width-1-4">Class</th>
                                             <th class="uk-width-1-4">Small<br><small>(Phones)</small><br><small style="font-weight: normal;">up to 767</small></th>
                                             <th class="uk-width-1-4">Medium<br><small>(Tablets)</small><br><small style="font-weight: normal;">768 to 959</small></th>
-                                            <th class="uk-width-1-4">Large<br><small>(Desktops)</small><br><small style="font-weight: normal;">960 and larger</small></th>
+                                            <th class="uk-width-1-4">Large<br><small>(Desktops)</small><br><small style="font-weight: normal;">960 to 1219</small></th>
+                                            <th class="uk-width-1-4">XLarge<br><small>(Big Desktops)</small><br><small style="font-weight: normal;">1220 and larger</small></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -924,15 +925,25 @@
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-muted">Hidden</td>
+                                            <td class="uk-text-muted">Hidden</td>
                                         </tr>
                                         <tr>
                                             <td><code>.uk-visible-medium</code></td>
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-muted">Hidden</td>
+                                            <td class="uk-text-muted">Hidden</td>
                                         </tr>
                                         <tr>
                                             <td><code>.uk-visible-large</code></td>
+                                            <td class="uk-text-muted">Hidden</td>
+                                            <td class="uk-text-muted">Hidden</td>
+                                            <td class="uk-text-success">Visible</td>
+                                            <td class="uk-text-muted">Hidden</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>.uk-visible-xlarge</code></td>
+                                            <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-success">Visible</td>
@@ -942,15 +953,25 @@
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-success">Visible</td>
+                                            <td class="uk-text-success">Visible</td>
                                         </tr>
                                         <tr>
                                             <td><code>.uk-hidden-medium</code></td>
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-muted">Hidden</td>
                                             <td class="uk-text-success">Visible</td>
+                                            <td class="uk-text-success">Visible</td>
                                         </tr>
                                         <tr>
                                             <td><code>.uk-hidden-large</code></td>
+                                            <td class="uk-text-success">Visible</td>
+                                            <td class="uk-text-success">Visible</td>
+                                            <td class="uk-text-muted">Hidden</td>
+                                            <td class="uk-text-success">Visible</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>.uk-hidden-xlarge</code></td>
+                                            <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-success">Visible</td>
                                             <td class="uk-text-muted">Hidden</td>

--- a/src/less/core/utility.less
+++ b/src/less/core/utility.less
@@ -483,11 +483,21 @@
  * Avoids setting display to `block` so it works also with `inline-block` and `table`
  */
 
-/* Desktop and bigger */
-@media (min-width: @breakpoint-large) {
+/* Big Desktop and bigger */
+@media (min-width: @breakpoint-xlarge) {
 
     .uk-visible-small { display: none !important; }
     .uk-visible-medium { display: none !important; }
+    .uk-visible-large { display: none !important; }
+    .uk-hidden-xlarge { display: none !important; }
+}
+
+/* Desktop */
+@media (min-width: @breakpoint-large) and (max-width: @breakpoint-large-max) {
+
+    .uk-visible-small { display: none !important; }
+    .uk-visible-medium { display: none !important; }
+    .uk-visible-xlarge { display: none !important; }
     .uk-hidden-large { display: none !important; }
 
 }
@@ -497,6 +507,7 @@
 
     .uk-visible-small { display: none !important; }
     .uk-visible-large { display: none !important ; }
+    .uk-visible-xlarge { display: none !important; }
     .uk-hidden-medium { display: none !important; }
 
 }
@@ -506,6 +517,7 @@
 
     .uk-visible-medium { display: none !important; }
     .uk-visible-large { display: none !important; }
+    .uk-visible-xlarge { display: none !important; }
     .uk-hidden-small { display: none !important; }
 
 }


### PR DESCRIPTION
Add the missing utility-class xlarge for Desktops bigger than 1220px.
With this, the responsive-width-classes and responsive-visibility-classes are equal.