### PR TITLE
Deactivate browser history navigation in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### WIP
+
+    - Deactivated browser history navigation (for IE 11) in modal
+
 ### 2.16.2 (January 15, 2015)
 
   - Updated modal header and footer

--- a/src/less/core/modal.less
+++ b/src/less/core/modal.less
@@ -64,6 +64,7 @@
  * 3. Allow scrolling for the modal dialog
  * 4. Mask the background page
  * 5. Fade-in transition
+ * 6. Deactivate browser history navigation in IE11
  */
 
 .uk-modal {
@@ -85,6 +86,8 @@
     opacity: 0;
     -webkit-transition: opacity 0.15s linear;
     transition: opacity 0.15s linear;
+    /* 6 */
+    touch-action: cross-slide-y pinch-zoom double-tap-zoom;
     .hook-modal;
 }
 


### PR DESCRIPTION
Because we are listening to swipe-events on the modal, we need to deactivate the browser-navigation for IE11 here (so that the swipe-gestures are recognized in IE11).

The bug appears in context of using the modal for the lightbox component. When I have a group of pictures and open them in the lightbox, the lightbox acts like a slideshow. On a touch device we then need the swipe-gestures to navigate through those images. But due to the well known problem, swipe gestures were not recognized in IE11 and IE11 started the browser history navigation. By deactivating this feature in the modal, UIkit can listen to the swipe-gestures as expected.