### PR TITLE
fix(gulp/indexthemes): add support for symlinks in themefolders

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ var watchmode  = gutil.env._.length && gutil.env._[0] == 'watch',
                 if (theme && t!=theme) return;
 
                 var path = f+'/'+t, uikit = path + '/uikit.less', customizer = path + '/uikit-customizer.less';
-                if (!(fs.lstatSync(path).isDirectory() && fs.existsSync(uikit))) return;
+                if (!((fs.lstatSync(path).isDirectory() || fs.lstatSync(path).isSymbolicLink()) && fs.existsSync(uikit))) return;
                 list.push({"name": t, "path": f+'/'+t, "uikit": uikit});
             });
         });


### PR DESCRIPTION
themes which are added as symlinks do not get parsed by indexthemes task since fs.isDirectory() returns false; added OR fs.isSymbolicLink()