### PR TITLE
Update form styling to be more specific. Fixes #894

### DIFF
--- a/src/less/core/form.less
+++ b/src/less/core/form.less
@@ -296,7 +296,7 @@
     padding: @form-padding;
     /* 4 */
     border: @form-border-width solid @form-border;
-    background: @form-background;
+    background-color: @form-background;
     color: @form-color;
     -webkit-transition: all linear 0.2s;
     transition: all linear 0.2s;
@@ -306,7 +306,7 @@
     &:focus {
         border-color: @form-focus-border;
         outline: 0;
-        background: @form-focus-background;
+        background-color: @form-focus-background;
         color: @form-focus-color;
         .hook-form-focus;
     }
@@ -412,7 +412,7 @@ input:not([type]).uk-form-large  {
 
 .uk-form-danger {
     border-color: @form-danger-border !important;
-    background: @form-danger-background !important;
+    background-color: @form-danger-background !important;
     color: @form-danger-color !important;
     .hook-form-danger;
 }
@@ -423,7 +423,7 @@ input:not([type]).uk-form-large  {
 
 .uk-form-success  {
     border-color: @form-success-border !important;
-    background: @form-success-background !important;
+    background-color: @form-success-background !important;
     color: @form-success-color !important;
     .hook-form-success;
 }


### PR DESCRIPTION
This fixes a bug/difficulty that I reported (https://github.com/uikit/uikit/issues/894) where applying form validation states to a form field overrode any background image, or other background-\* styles. Since the validation styles were only setting the background-color anyways, this seemed like a good change so users don't have to go out of their way to make other background-\* styles stick whether or not validation classes have been applied.
