### PR TITLE
border-box by default

### DIFF
--- a/src/less/components/nestable.less
+++ b/src/less/components/nestable.less
@@ -105,8 +105,6 @@
  ========================================================================== */
 
 .uk-nestable-placeholder {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     margin-bottom: @nestable-item-margin-bottom;
     border: 1px dashed @nestable-placeholder-border;
     .hook-nestable-placeholder;

--- a/src/less/components/search.less
+++ b/src/less/components/search.less
@@ -141,28 +141,24 @@
 .uk-search-field::-moz-placeholder { opacity: 1; }
 
 /*
- * 1. Define consistent box sizing.
- * 2. Address margins set differently in Firefox/IE and Chrome/Safari/Opera.
- * 3. Remove `border-radius` in iOS.
- * 4. Correct `font` properties and `color` not being inherited.
- * 5. Remove default style in iOS.
- * 6. Style
+ * 1. Address margins set differently in Firefox/IE and Chrome/Safari/Opera.
+ * 2. Remove `border-radius` in iOS.
+ * 3. Correct `font` properties and `color` not being inherited.
+ * 4. Remove default style in iOS.
+ * 5. Style
  */
 
 .uk-search-field {
     /* 1 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    /* 2 */
     margin: 0;
-    /* 3 */
+    /* 2 */
     border-radius: 0;
-    /* 4 */
+    /* 3 */
     font: inherit;
     color: @search-color;
-    /* 5 */
+    /* 4 */
     -webkit-appearance: none;
-    /* 6 */
+    /* 5 */
     width: @search-width;
     height: @search-height;
     padding: 0 0 0 @search-padding;

--- a/src/less/components/slidenav.less
+++ b/src/less/components/slidenav.less
@@ -56,19 +56,15 @@
 
 /*
  * 1. Required for `a` elements
- * 2. Dimension
- * 3. Style
+ * 2. Style
  */
 
 .uk-slidenav {
     /* 1 */
     display: inline-block;
-    /* 2 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     width: @slidenav-width;
     height: @slidenav-height;
-    /* 3 */
+    /* 2 */
     line-height: @slidenav-line-height;
     color: @slidenav-color;
     font-size: @slidenav-font-size;

--- a/src/less/components/sticky.less
+++ b/src/less/components/sticky.less
@@ -18,15 +18,8 @@
    Component: Sticky
  ========================================================================== */
 
-/*
- * 1. More robust if padding and border are used
- */
-
 [data-uk-sticky].uk-active {
     z-index: @sticky-z-index;
-    /* 1 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
 }
 
 /*

--- a/src/less/core/badge.less
+++ b/src/less/core/badge.less
@@ -59,8 +59,6 @@ a.uk-badge:hover { color: @badge-hover-color; }
  ========================================================================== */
 
 .uk-badge-notification {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     min-width: @badge-notification-line-height;
     border-radius: 500px;
     font-size: @badge-notification-font-size;

--- a/src/less/core/base.less
+++ b/src/less/core/base.less
@@ -99,6 +99,7 @@ html {
     color: @base-body-color;
     /* 4 */
     box-sizing: border-box;
+    -moz-box-sizing: border-box;
     .hook-base-body;
 
     *, *:before, *:after {

--- a/src/less/core/base.less
+++ b/src/less/core/base.less
@@ -103,6 +103,7 @@ html {
 
     *, *:before, *:after {
         box-sizing: inherit;
+        -moz-box-sizing: inherit;
     }
 }
 

--- a/src/less/core/base.less
+++ b/src/less/core/base.less
@@ -85,6 +85,7 @@
  * 1. Normalizes default `font-family` and sets `font-size` here to support `rem` units
  * 2. Prevents iOS text size adjust after orientation change, without disabling user zoom
  * 3. Style
+ * 4. Border-box by default, with other 3rd party components able to override
  */
 
 html {
@@ -96,7 +97,13 @@ html {
     /* 3 */
     background: @base-body-background;
     color: @base-body-color;
+    /* 4 */
+    box-sizing: border-box;
     .hook-base-body;
+
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
 }
 
 /*
@@ -233,9 +240,8 @@ sub { bottom: -0.25em; }
 
 /*
  * 1. Responsiveness: Sets a maximum width relative to the parent and auto scales the height
- * 2. Corrects `max-width` behavior if padding and border are used
- * 3. Remove border when inside `a` element in IE 8/9/10.
- * 4. Remove the gap between images and the bottom of their containers
+ * 2. Remove border when inside `a` element in IE 8/9/10.
+ * 3. Remove the gap between images and the bottom of their containers
  */
 
 img {
@@ -243,11 +249,8 @@ img {
     max-width: 100%;
     height: auto;
     /* 2 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    /* 3 */
     border: 0;
-    /* 4 */
+    /* 3 */
     vertical-align: middle;
 }
 
@@ -438,7 +441,7 @@ pre {
 }
 
 
-/* Selection pseudo-element 
+/* Selection pseudo-element
  ========================================================================== */
 
 ::-moz-selection {

--- a/src/less/core/button.less
+++ b/src/less/core/button.less
@@ -140,8 +140,6 @@
     text-transform: none;
     /* 7 */
     display: inline-block;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     padding: 0 @button-padding-horizontal;
     background: @button-background;
     vertical-align: middle;

--- a/src/less/core/dropdown.less
+++ b/src/less/core/dropdown.less
@@ -59,9 +59,8 @@
 /*
  * 1. Hide by default
  * 2. Set position
- * 3. Box-sizing is needed for `uk-dropdown-justify`
- * 4. Set style
- * 5. Reset button group whitespace hack
+ * 3. Set style
+ * 4. Reset button group whitespace hack
  */
 
 .uk-dropdown {
@@ -73,15 +72,12 @@
     left: 0;
     z-index: @dropdown-z-index;
     /* 3 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    /* 4 */
     width: @dropdown-width;
     margin-top: @dropdown-margin-top;
     padding: @dropdown-padding;
     background: @dropdown-background;
     color: @dropdown-color;
-    /* 5 */
+    /* 4 */
     font-size: @dropdown-font-size;
     vertical-align: top;
     .hook-dropdown;

--- a/src/less/core/form.less
+++ b/src/less/core/form.less
@@ -113,27 +113,19 @@
  ========================================================================== */
 
 /*
- * 1. Define consistent box sizing.
- *    Default is `content-box` with following exceptions set to `border-box`
- *    `button`, `select`, `input[type="checkbox"]` and `input[type="radio"]`
- *    `input[type="search"]` in Chrome, Safari and Opera
- *    `input[type="color"]` in Firefox
- * 2. Address margins set differently in Firefox/IE and Chrome/Safari/Opera.
- * 3. Remove `border-radius` in iOS.
- * 4. Correct `font` properties and `color` not being inherited.
+ * 1. Address margins set differently in Firefox/IE and Chrome/Safari/Opera.
+ * 2. Remove `border-radius` in iOS.
+ * 3. Correct `font` properties and `color` not being inherited.
  */
 
 .uk-form input,
 .uk-form select,
 .uk-form textarea {
     /* 1 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    /* 2 */
     margin: 0;
-    /* 3 */
+    /* 2 */
     border-radius: 0;
-    /* 4 */
+    /* 3 */
     font: inherit;
     color: inherit;
 }

--- a/src/less/core/grid.less
+++ b/src/less/core/grid.less
@@ -273,17 +273,10 @@
     display: flex;
 }
 
-/*
- * 1. Behave like a block element
- */
-
 .uk-grid-match > * > * {
     -ms-flex: none;
     -webkit-flex: none;
     flex: none;
-    /* 1 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     width: 100%;
 }
 
@@ -292,8 +285,6 @@
  ========================================================================== */
 
 [class*='uk-grid-width'] > * {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     width: 100%;
 }
 
@@ -357,8 +348,6 @@
  ========================================================================== */
 
 [class*='uk-width'] {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     width: 100%;
 }
 

--- a/src/less/core/icon.less
+++ b/src/less/core/icon.less
@@ -131,8 +131,6 @@
  ========================================================================== */
 
 .uk-icon-button {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     display: inline-block;
     width: @icon-button-width;
     height: @icon-button-height;

--- a/src/less/core/modal.less
+++ b/src/less/core/modal.less
@@ -110,28 +110,24 @@
 
 /*
  * 1. Create position context for caption, spinner and close button
- * 2. Set box sizing
- * 3. Min-height needed for initial loading and spinner
- * 4. Set style
- * 5. Slide-in transition
+ * 2. Min-height needed for initial loading and spinner
+ * 3. Set style
+ * 4. Slide-in transition
  */
 
 .uk-modal-dialog {
     /* 1 */
     position: relative;
-    /* 2 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     margin: @modal-dialog-margin-vertical auto;
     padding: @modal-dialog-padding;
     width: @modal-dialog-width;
     max-width: 100%;
     max-width: ~"calc(100% - 20px)";
-    /* 3 */
+    /* 2 */
     min-height: 200px;
-    /* 4 */
+    /* 3 */
     background: @modal-dialog-background;
-    /* 5 */
+    /* 4 */
     opacity: 0;
     -webkit-transform: translateY(-100px);
     transform: translateY(-100px);

--- a/src/less/core/navbar.less
+++ b/src/less/core/navbar.less
@@ -118,8 +118,6 @@
 
 .uk-navbar-nav > li > a {
     display: block;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     text-decoration: none;
     /* 1 */
     height: @navbar-nav-height;
@@ -190,8 +188,6 @@
 .uk-navbar-content,
 .uk-navbar-brand,
 .uk-navbar-toggle {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     display: block;
     height: @navbar-nav-height;
     padding: 0 @navbar-nav-padding-horizontal;

--- a/src/less/core/overlay.less
+++ b/src/less/core/overlay.less
@@ -438,8 +438,6 @@
 .uk-overlay-area-content {
     /* 1 */
     display: inline-block;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     width: 100%;
     vertical-align: middle;
     /* 2 */

--- a/src/less/core/progress.less
+++ b/src/less/core/progress.less
@@ -51,8 +51,6 @@
  */
 
 .uk-progress {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     height: @progress-height;
     margin-bottom: @progress-margin-vertical;
     background: @progress-background;

--- a/src/less/core/thumbnail.less
+++ b/src/less/core/thumbnail.less
@@ -59,9 +59,6 @@
     /* 2 */
     max-width: 100%;
     /* 3 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    /* 3 */
     margin: 0;
     /* 4 */
     padding: @thumbnail-padding;

--- a/src/less/core/tooltip.less
+++ b/src/less/core/tooltip.less
@@ -50,8 +50,6 @@
     position: absolute;
     z-index: @tooltip-z-index;
     /* 3 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     max-width: @tooltip-max-width;
     padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
     /* 4 */

--- a/src/less/core/utility.less
+++ b/src/less/core/utility.less
@@ -68,8 +68,6 @@
  ========================================================================== */
 
 .uk-container {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     max-width: @utility-container-max-width;
     padding: 0 @utility-container-padding-horizontal;
     .hook-container;
@@ -242,15 +240,6 @@
  ========================================================================== */
 
 /*
- * More robust if padding and border are used
- */
-
-[class*='uk-height'] {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
-/*
  * Useful to extend the `html` and `body` element to the full height of the page.
  */
 
@@ -269,16 +258,6 @@
 /* Responsive objects
  * Note: Images are already responsive by default, see Base component
  ========================================================================== */
-
-/*
- * 1. Corrects `max-width` and `max-height` behavior if padding and border are used
- */
-
-.uk-responsive-width,
-.uk-responsive-height {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
 
 /*
  * Responsiveness: Sets a maximum width relative to the parent and auto scales the height
@@ -416,8 +395,6 @@
  */
 
 .uk-scrollable-box {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     height: @utility-scrollable-box-height;
     padding: @utility-scrollable-box-padding;
     border: @utility-scrollable-box-border-width solid @utility-scrollable-box-border;


### PR DESCRIPTION
I've pushed for this a few times, so decided to go ahead and create a PR for it. I think [CSS Tricks](http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/) says it best, but `box-sizing: border-box` has become the universal standard for base styles to use. I've left all `box-sizing` attributes that require overrides (which is exactly how it should be) and only inherit down `border-box` to components that don't override them.

This makes UIkit smaller and smarter with saner defaults and proper inheritance.
