### PR TITLE
move min-height for spinner to uk-modal-dialog-lightbox

### DIFF
--- a/docs/modal.html
+++ b/docs/modal.html
@@ -229,29 +229,6 @@
 
                             <hr class="uk-article-divider">
 
-                            <h2 id="modal-with-spinner"><a href="#modal-with-spinner" class="uk-link-reset">Modal spinner</a></h2>
-
-                            <p>To place a spinning icon inside your modal, add the <code>.uk-modal-spinner</code> class to a <code>&lt;div&gt;</code> element inside the modal dialog.</p>
-
-                            <h3 class="tm-article-subtitle">Example</h3>
-
-                            <a class="uk-button" href="#modal-spinner" data-uk-modal>Open</a>
-                            <div id="modal-spinner" class="uk-modal">
-                                <div class="uk-modal-dialog">
-                                    <div class="uk-modal-spinner"></div>
-                                </div>
-                            </div>
-
-                            <h3 class="tm-article-subtitle">Markup</h3>
-
-<pre><code>&lt;div class="uk-modal"&gt;
-    &lt;div class="uk-modal-dialog"&gt;
-        &lt;div class="uk-modal-spinner"&gt;...&lt;/div&gt;
-    &lt;/div&gt;
-&lt;/div&gt;</code></pre>
-
-                            <hr class="uk-article-divider">
-
                             <h2 id="lightbox-modifier"><a href="#lightbox-modifier" class="uk-link-reset">Lightbox modifier</a></h2>
 
                             <p>To create a lightbox-like modal dialog, just add the <code>.uk-modal-dialog-lightbox</code> class. This can be useful, if you want to use the modal as a lightbox for your images. The close button will adjust its position automatically to the dialog.</p>
@@ -280,6 +257,29 @@
 &lt;/div&gt;</code></pre>
 
                         <p><span class="uk-badge">NOTE</span> When creating a close button within the lightbox modifier, we also recommend adding the <code>.uk-close-alt</code> class from the <a href="close.html">Close component</a> to the close button to give your button a styling that fits the lightbox modal.</p>
+
+                        <hr class="uk-article-divider">
+
+                        <h2 id="modal-with-spinner"><a href="#modal-with-spinner" class="uk-link-reset">Modal spinner</a></h2>
+
+                        <p>To place a spinning icon inside your modal, add the <code>.uk-modal-spinner</code> class to a <code>&lt;div&gt;</code> element inside the modal dialog-lightbox.</p>
+
+                        <h3 class="tm-article-subtitle">Example</h3>
+
+                        <a class="uk-button" href="#modal-spinner" data-uk-modal>Open</a>
+                        <div id="modal-spinner" class="uk-modal">
+                            <div class="uk-modal-dialog uk-modal-dialog-lightbox">
+                                <div class="uk-modal-spinner"></div>
+                            </div>
+                        </div>
+
+                        <h3 class="tm-article-subtitle">Markup</h3>
+
+<pre><code>&lt;div class="uk-modal"&gt;
+&lt;div class="uk-modal-dialog uk-modal-dialog-lightbox"&gt;
+&lt;div class="uk-modal-spinner"&gt;...&lt;/div&gt;
+&lt;/div&gt;
+&lt;/div&gt;</code></pre>
 
                         <hr class="uk-article-divider">
 

--- a/src/less/core/modal.less
+++ b/src/less/core/modal.less
@@ -111,9 +111,8 @@
 /*
  * 1. Create position context for caption, spinner and close button
  * 2. Set box sizing
- * 3. Min-height needed for initial loading and spinner
- * 4. Set style
- * 5. Slide-in transition
+ * 3. Set style
+ * 4. Slide-in transition
  */
 
 .uk-modal-dialog {
@@ -128,10 +127,8 @@
     max-width: 100%;
     max-width: ~"calc(100% - 20px)";
     /* 3 */
-    min-height: 200px;
-    /* 4 */
     background: @modal-dialog-background;
-    /* 5 */
+    /* 4 */
     opacity: 0;
     -webkit-transform: translateY(-100px);
     transform: translateY(-100px);
@@ -193,6 +190,7 @@
 .uk-modal-dialog-lightbox {
     margin: 15px auto;
     padding: 0;
+    min-height: 200px;
     max-width: 95%;
     max-width: ~"calc(100% - 30px)";
     .hook-modal-dialog-lightbox;

--- a/tests/core/modal.html
+++ b/tests/core/modal.html
@@ -86,7 +86,7 @@
             </div>
 
             <div id="modal-spinner" class="uk-modal">
-                <div class="uk-modal-dialog">
+                <div class="uk-modal-dialog uk-modal-dialog-lightbox">
                     <div class="uk-modal-spinner"></div>
                 </div>
             </div>


### PR DESCRIPTION
To prevent modals with small messages to be too high, it is not desirable to have a min-height applied to the default `uk-modal-dialog` class.
A dialog with one line and a default modal-header and footer is also too high:
![screenshot_13](https://cloud.githubusercontent.com/assets/5442402/6217657/6d220464-b616-11e4-909f-ef9bf3e07610.png)
Applying the `min-height` to the `uk-modal-dialog-lightbox` was suggested by @aheinze in the chat. It solves this problem, but it would mean breaking existing markup for modals with spinners.
I didn't edit changelog in this PR, but if this is merged, it should be mentioned in update guidelines.