### PR TITLE
Unused variable in base.less (default theme)

### DIFF
--- a/themes/default/base.less
+++ b/themes/default/base.less
@@ -37,7 +37,6 @@
 @base-hr-border:                                @global-border;
 
 @base-blockquote-border:                        @global-border;
-@base-blockquote-small-color:                   @global-muted-color;
 @base-blockquote-font-size:                     round((@global-font-size * 1.14)); // 16px / 18px
 @base-blockquote-line-height:                   round((@base-blockquote-font-size * 1.36)); // 22px / 24px
 


### PR DESCRIPTION
Delete @base-blockquote-small-color, which is no longer used.