### PR TITLE
Typo in docs - icon.html

### DIFF
--- a/docs/icon.html
+++ b/docs/icon.html
@@ -182,7 +182,7 @@
                             <h4 class="tm-article-subtitle">Example</h4>
 
                             <blockquote>
-                                <p><i class="uk-icon-quote-left uk-icon-large align-left"></i>The &lt;blockquote&gt; element defines a long quotation which also creates a new block by inserting white space before and after the blockquote element.</p>
+                                <p><i class="uk-icon-quote-left uk-icon-large uk-align-left"></i>The &lt;blockquote&gt; element defines a long quotation which also creates a new block by inserting white space before and after the blockquote element.</p>
                             </blockquote>
 
                             <hr class="uk-article-divider">


### PR DESCRIPTION
Non-existing class .align-left, there should be .uk-align-left