### PR TITLE
Add missing classes do text.html doc

### DIFF
--- a/docs/text.html
+++ b/docs/text.html
@@ -178,6 +178,14 @@
                                             <td>Aligns text to the left.</td>
                                         </tr>
                                         <tr>
+                                            <td><code>.uk-text-left-small</code></td>
+                                            <td>Aligns text to the left only on small devices.</td>
+                                        </tr>
+                                        <tr>
+                                            <td><code>.uk-text-left-medium</code></td>
+                                            <td>Aligns text to the left on medium and small devices.</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>.uk-text-right</code></td>
                                             <td>Aligns text to the right.</td>
                                         </tr>


### PR DESCRIPTION
Add .uk-text-left-small and .uk-text-left-medium classes (introduced in 2.16.0).