### PR TITLE
Fix space-between example

### DIFF
--- a/docs/flex.html
+++ b/docs/flex.html
@@ -186,15 +186,15 @@
 
                             <h3 class="tm-article-subtitle">Example</h3>
 
-                           <div class="uk-flex uk-flex-middle uk-flex-center uk-flex-space-between">
+                           <div class="uk-flex uk-flex-middle uk-flex-space-between">
                                <div class="uk-width-1-4 uk-panel uk-panel-box" style="height: 50px;">Box</div>
-                               <div class="uk-width-1-4 uk-panel uk-panel-box uk-margin-left" style="height: 70px;">Box</div>
-                               <div class="uk-width-1-4 uk-panel uk-panel-box uk-margin-left" style="height: 100px;">Box</div>
+                               <div class="uk-width-1-4 uk-panel uk-panel-box" style="height: 70px;">Box</div>
+                               <div class="uk-width-1-4 uk-panel uk-panel-box" style="height: 100px;">Box</div>
                            </div>
 
                             <h3 class="tm-article-subtitle">Markup</h3>
 
-<pre><code>&lt;div class="uk-flex uk-flex-middle uk-flex-center uk-flex-space-between"&gt;...&lt;/div&gt;</code></pre>
+<pre><code>&lt;div class="uk-flex uk-flex-middle uk-flex-space-between"&gt;...&lt;/div&gt;</code></pre>
 
                             <hr class="uk-article-divider">
 


### PR DESCRIPTION
The example in the [flex docs](http://getuikit.com/docs/flex.html) is not aligned properly in Chrome:
![screenshot_37](https://cloud.githubusercontent.com/assets/5442402/6333423/2cc47650-bb8d-11e4-8d74-c44c25a1c6f9.png)
It seems to me that this example used to be a centered one, and some markup was left over. The usage of both `uk-flex-center` and `uk-flex-space-between` obviously confused Chrome.
I removed  `uk-flex-center` from markup and example markup, and removed the margin which is not needed when using space-between.