### PR TITLE
Prevent off-center full screen display in Chrome

### DIFF
--- a/src/less/core/cover.less
+++ b/src/less/core/cover.less
@@ -61,6 +61,14 @@
     transform: translate(-50%,-50%);
 }
 
+/*
+ * Prevent off-center fullscreen display in Chrome
+ */
+
+[data-uk-cover]:-webkit-full-screen {
+  -webkit-transform: translate(0,0);
+  transform: translate(0,0);
+}
 
 // Hooks
 // ========================================================================


### PR DESCRIPTION
When you click the fullscreen button, or double-click on a video that is in an iframe with `data-uk-cover` attribute, the full screen image is off-centered. I tested it for Chrome, Firefox and IE latest versions, only Chrome shows this behaviour.
![cover-fullscreen](https://cloud.githubusercontent.com/assets/5442402/6647534/8efc2066-c9cf-11e4-9eb6-8497a4b43de8.png)
This seems to be caused by the `transform: translate(-50%,-50%);` at https://github.com/uikit/uikit/blob/master/src/less/core/cover.less#L60 that is not overridden by the user agent stylesheet, as `top: -50%` and `left: 50%` are.
Reverting the transform with the same selector as the user-agent stylesheet does the job.
