### PR TITLE
Prevent offcanvas error when target is a link

### DIFF
--- a/src/js/core/offcanvas.js
+++ b/src/js/core/offcanvas.js
@@ -105,9 +105,14 @@
                 }
 
                 UI.$doc.one('hide.uk.offcanvas', function() {
-
-                    var target = UI.$(href);
-
+                    var target;
+                    
+                    try {
+                        target = UI.$(href);
+                    } catch (e){
+                        target = ""
+                    }
+                    
                     if (!target.length) {
                         target = UI.$('[name="'+href.replace('#','')+'"]');
                     }


### PR DESCRIPTION
reported in #1087

Stack example on ember app:

 Error while processing route: channel Syntax error, unrecognized expression: #/channels/dormroomtycoon Error: Syntax error, unrecognized expression: #/channels/dormroomtycoon
    at Function.Sizzle.error (http://localhost:4200/assets/vendor.js:1611:8)
    at Sizzle.tokenize (http://localhost:4200/assets/vendor.js:2228:11)
    at Sizzle.select (http://localhost:4200/assets/vendor.js:2632:20)
    at Function.Sizzle (http://localhost:4200/assets/vendor.js:1008:9)
    at jQuery.fn.extend.find (http://localhost:4200/assets/vendor.js:2848:11)
    at jQuery.fn.init (http://localhost:4200/assets/vendor.js:2965:38)
    at Object.jQuery [as $] (http://localhost:4200/assets/vendor.js:193:10)
    at HTMLDocument.<anonymous> (http://localhost:4200/assets/vendor.js:82201:37)
    at HTMLDocument.jQuery.fn.extend.on.fn (http://localhost:4200/assets/vendor.js:5358:19)
    at HTMLDocument.jQuery.event.dispatch (http://localhost:4200/assets/vendor.js:4785:9)