### PR TITLE
added hide.uk.dropdown event

### DIFF
--- a/docs/dropdown.html
+++ b/docs/dropdown.html
@@ -1015,6 +1015,10 @@
                                             <td>Triggered on dropdown show</td>
                                         </tr>
                                         <tr>
+                                            <td><code>hide.uk.dropdown</code></td>
+                                            <td>Triggered on dropdown hide</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>stack.uk.dropdown</code></td>
                                             <td>Triggered when a dropdown stacks to fit into screen</td>
                                         </tr>

--- a/src/js/core/dropdown.js
+++ b/src/js/core/dropdown.js
@@ -132,11 +132,8 @@
 
             UI.$html.off("click.outer.dropdown");
 
-            if (active && active[0] != this.element[0]) {
-                active.removeClass('uk-open');
-
-                // Update ARIA
-                active.attr('aria-expanded', 'false');
+            if (active && active != this) {
+                active.hide();
             }
 
             if (hoverIdle) {
@@ -152,19 +149,26 @@
             this.trigger('show.uk.dropdown', [this]);
 
             UI.Utils.checkDisplay(this.dropdown, true);
-            active = this.element;
+            active = this;
 
             this.registerOuterClick();
         },
 
         hide: function() {
             this.element.removeClass('uk-open');
+
+            if (this.remainIdle) {
+                clearTimeout(this.remainIdle);
+            }
+
             this.remainIdle = false;
 
             // Update ARIA
             this.element.attr('aria-expanded', 'false');
 
-            if (active && active[0] == this.element[0]) active = false;
+            this.trigger('hide.uk.dropdown', [this]);
+
+            if (active == this) active = false;
         },
 
         registerOuterClick: function(){
@@ -183,7 +187,7 @@
 
                     var $target = UI.$(e.target);
 
-                    if (active && active[0] == $this.element[0] && ($target.is("a:not(.js-uk-prevent)") || $target.is(".uk-dropdown-close") || !$this.dropdown.find(e.target).length)) {
+                    if (active == $this && ($target.is("a:not(.js-uk-prevent)") || $target.is(".uk-dropdown-close") || !$this.dropdown.find(e.target).length)) {
                         $this.hide();
                         UI.$html.off("click.outer.dropdown");
                     }


### PR DESCRIPTION
The dropdown component now throws a hide.uk.dropdown event.

This lead me to the case, that the event was fired after the remainIdle-timeout and not immediately, when it was hidden by hovering over another dropdown (line 135).

Because of this I also changed the active-handling a bit. The active-var now holds a reference to the (dropdown) object, not to the element (line 152). When hovering over another dropdown, the active element is no longer hidden by the new dropdown, but by calling the hide()-method of the active dropdown object (line 136). This way, the hide-method is the only place, that handles the hiding of a dropdown.

In the hide function I also clear the remainIdle timeout, to prevent the method to be called twice in the case described above.