### PR TITLE
frame rate issues with sticky elements

### DIFF
--- a/src/less/components/sticky.less
+++ b/src/less/components/sticky.less
@@ -18,16 +18,21 @@
    Component: Sticky
  ========================================================================== */
 
-/*
- * 1. More robust if padding and border are used
- */
+ /*
+  * 1. More robust if padding and border are used
+  * 2. Resolve frame-rate issues on devices with lower frame-rates
+  * Forces hardware acceleration
+  */
 
-[data-uk-sticky].uk-active {
-    z-index: @sticky-z-index;
-    /* 1 */
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
+ [data-uk-sticky].uk-active {
+     z-index: @sticky-z-index;
+     /* 1 */
+     -moz-box-sizing: border-box;
+     box-sizing: border-box;
+     /* 2 */
+     -webkit-backface-visibility: hidden;
+     backface-visibility: hidden;
+ }
 
 /*
  * Faster animations


### PR DESCRIPTION
Noticed this when a sticky header was used on devices with lower frame-rates/video cards. Original thought was to use `transform3d(0, 0, 0)`, but that impacted elements along the z axis. This is a lower fidelity change that enabled hardware acceleration.