### PR TITLE
match example to actual code cover-docs

### DIFF
--- a/docs/cover.html
+++ b/docs/cover.html
@@ -226,7 +226,7 @@
 
 <pre><code>&lt;div class="uk-cover-background uk-position-relative"&gt;
     &lt;img class="uk-invisible" src="" width="" height="" alt=""&gt;
-    &lt;div class="uk-position-cover uk-flex-center uk-flex-middle"&gt;...&lt;/div&gt;
+    &lt;div class="uk-position-cover uk-flex uk-flex-center uk-flex-middle"&gt;...&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 
                         </article>


### PR DESCRIPTION
To match the actual example, `uk-flex` needs to be added to the `position-cover` element to actually work.