### PR TITLE
AMD definition is not correct for component "lightbox"

### DIFF
--- a/src/js/components/lightbox.js
+++ b/src/js/components/lightbox.js
@@ -7,7 +7,7 @@
     }
 
     if (typeof define == "function" && define.amd) { // AMD
-        define(["uikit-lightbox"], function(){
+        define("uikit-lightbox", ["uikit"], function(){
             return component || addon(UIkit);
         });
     }


### PR DESCRIPTION
Set the definition as for a plugin