### PR TITLE
Fix broken transition to the same slide

### DIFF
--- a/src/js/components/slideshow.js
+++ b/src/js/components/slideshow.js
@@ -261,7 +261,7 @@
 
         show: function(index, direction) {
 
-            if (this.animating) return;
+            if (this.animating || this.current == index) return;
 
             this.animating = true;
 


### PR DESCRIPTION
Currently when the show fn is called and the next index is equal to the current one, the image becomes hidden.

This can be reproduced by creating a slideshow with one element and a slidenav element.