### PR TITLE
Clean up transition when show is passed the current index

### DIFF
--- a/src/js/components/slideshow.js
+++ b/src/js/components/slideshow.js
@@ -261,7 +261,7 @@
 
         show: function(index, direction) {
 
-            if (this.animating) return;
+            if (this.animating || this.current == index) return;
 
             this.animating = true;
 


### PR DESCRIPTION
In the slideshow component:

If the show function is called with an index equal to the current one, the image at the slide becomes hidden. This fix returns from show with no action when this is the case.