### PR TITLE
Update datatype sortable option

### DIFF
--- a/docs/sortable.html
+++ b/docs/sortable.html
@@ -236,7 +236,7 @@
                                             <td><code>handleClass</code></td>
                                             <td>string</td>
                                             <td>''</td>
-                                            <td>CSS selector to define elements which can trigger sorting</td>
+                                            <td>Custom class to define elements which can trigger sorting</td>
                                         </tr>
                                         <tr>
                                             <td><code>dragCustomClass</code></td>


### PR DESCRIPTION
At http://getuikit.com/docs/sortable.html#javascript-options the description for the option `handleClass` sais `CSS selector to define elements which can trigger sorting`. But when adding a selector `.my-class`, an error `Uncaught Error: Syntax error, unrecognized expression: ..my-class` is thrown.
Changing the text to `Custom class to..` fixes the confusion.