### PR TITLE
cleanup sortable.js

### DIFF
--- a/src/js/components/sortable.js
+++ b/src/js/components/sortable.js
@@ -121,13 +121,6 @@
                 currentlyDraggingTarget  = null,
                 children;
 
-            Object.keys(this.options).forEach(function(key){
-
-                if (String($this.options[key]).indexOf('Class')!=-1) {
-                    $this.options[key] = $this.options[key];
-                }
-            });
-
             if (supportsDragAndDrop) {
                 this.element.children().attr("draggable", "true");
 


### PR DESCRIPTION
leftover from prefixing. Don't think this does anything usefull :). https://github.com/uikit/uikit/commit/5c75488399d955e34b79c79c94b5688c887ad385#diff-06d21a7c7966b5e43a098e91c6879abbR118