### PR TITLE
Add noChildClass

### DIFF
--- a/docs/nestable.html
+++ b/docs/nestable.html
@@ -353,6 +353,12 @@
                                             <td>uk-nestable-placeholder</td>
                                             <td>Class for placeholder of currently dragged element</td>
                                         </tr>
+                                            <tr>
+                                            <td><code>noChildClass</code></td>
+                                            <td>string</td>
+                                            <td>uk-nestable-nochildren</td>
+                                            <td>Elements with this class cannot have children attached to them.</td>
+                                        </tr>
                                         <tr>
                                             <td><code>noDragClass</code></td>
                                             <td>string</td>

--- a/src/js/components/nestable.js
+++ b/src/js/components/nestable.js
@@ -72,6 +72,7 @@
             collapsedClass  : '{prefix}collapsed',
             placeClass      : '{prefix}nestable-placeholder',
             noDragClass     : '{prefix}nestable-nodrag',
+            noChildrenClass : '{prefix}nestable-nochildren',
             emptyClass      : '{prefix}nestable-empty',
             group           : 0,
             maxDepth        : 10,
@@ -490,7 +491,7 @@
                 mouse.distAxX = 0;
                 prev = this.placeEl.prev(opt.itemNodeName);
                 // increase horizontal level if previous sibling exists and is not collapsed
-                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass)) {
+                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass) && prev.find("."+opt.itemClass+" ."+opt.noChildrenClass).length <= 0) {
                     // cannot increase level when item above is collapsed
                     list = prev.find(opt.listNodeName).last();
                     // check if depth limit has reached


### PR DESCRIPTION
Adds noChildClass, which prevents an item from having children- very useful for separators / bottom-level-items.