### PR TITLE
Check for updated title text

### DIFF
--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -35,6 +35,13 @@
             // init code
             UI.$html.on("mouseenter.tooltip.uikit focus.tooltip.uikit", "[data-uk-tooltip]", function(e) {
                 var ele = UI.$(this);
+                
+                //check existing tooltips to see if title attr has been updated
+                if (ele.data("tooltip") 
+                    && (!(ele.attr("data-cached-title") === ele.data("cached-title")))) {
+                   ele.removeData("tooltip");
+                   ele.removeData("cached-title");
+                }
 
                 if (!ele.data("tooltip")) {
                     var obj = UI.tooltip(ele, UI.Utils.options(ele.attr("data-uk-tooltip")));


### PR DESCRIPTION
Check if data-attr-title has been updated since existing tooltip was initialized, and wipe it out for re-creation if needed. Allows updating tooltip text via element attributes, which was something I expected to happen.