### PR TITLE
Move misc contrast hook

### DIFF
--- a/src/less/core/contrast.less
+++ b/src/less/core/contrast.less
@@ -393,18 +393,14 @@
 
     .uk-text-muted { color: @contrast-text-muted-color !important; }
     .uk-text-primary { color: @contrast-text-primary-color !important; }
-
-
-    // Misc hook
-    // ========================================================================
-
-    .hook-contrast-misc;
-
 }
 
 
 // Hooks
 // ========================================================================
+
+.hook-contrast-misc;
+
 
 .hook-contrast-base-code() {}
 


### PR DESCRIPTION
Every other misc hook is outside any declarations, this keeps the contrast hook consistent with everything else.
