### PR TITLE
Fix for Dropdown opening with jQuery 3.0

### DIFF
--- a/src/js/core/dropdown.js
+++ b/src/js/core/dropdown.js
@@ -220,10 +220,10 @@
 
             var $this     = this,
                 dropdown  = this.dropdown.css("margin-" + UI.langdirection, ""),
-                offset    = dropdown.show().offset(),
+                offset    = dropdown.show().offset() || {left:0, top:0},
                 width     = dropdown.outerWidth(),
                 boundarywidth  = this.boundary.width(),
-                boundaryoffset = this.boundary.offset() ? this.boundary.offset().left:0;
+                boundaryoffset = this.boundary[0] !== UI.$win[0] && this.boundary.offset() ? this.boundary.offset().left:0;
 
             // centered dropdown
             if (this.centered) {


### PR DESCRIPTION
jQuery 3.0 brings changes to `$(elem).offset()` method that breaks dropdown from working.
Main change happened here: https://github.com/jquery/jquery/commit/1617479fcf7cbdaf33dc9334ed10a0f30bf14687
However, current version is simplified even more.
Even though jQuery 3.0 is still a work in progress, this fix doesn't break anything for previous versions of jQuery and jQuery itself is not likely to change according to this thread: https://github.com/jquery/jquery/issues/2310

This commit fixes two issues:
* for whatever reason you set `this.boundary` to `UI.$win`, calling `$(window).offset()` now produces error `getBoundingClientRect is not a function` and stops further code execution
* another thing is that calling `$(elem).offset()` on invisible element now produces `undefined`, so we need to handle that as well