### PR TITLE
Allow html in label form-password

### DIFF
--- a/src/js/components/form-password.js
+++ b/src/js/components/form-password.js
@@ -50,12 +50,13 @@
                 if($this.input.length) {
                     var type = $this.input.attr("type");
                     $this.input.attr("type", type=="text" ? "password":"text");
-                    $this.element.text($this.options[type=="text" ? "lblShow":"lblHide"]);
+                    $this.element.html($this.options[type=="text" ? "lblShow":"lblHide"]);
                 }
             });
 
             this.input = this.element.next("input").length ? this.element.next("input") : this.element.prev("input");
-            this.element.text(this.options[this.input.is("[type='password']") ? "lblShow":"lblHide"]);
+            this.element.html(this.options[this.input.is("[type='password']") ? "lblShow":"lblHide"]);
+
 
             this.element.data("formPassword", this);
         }

--- a/tests/components/form-password.html
+++ b/tests/components/form-password.html
@@ -28,6 +28,18 @@
                     </div>
                 </div>
 
+                <div class="uk-form-row">
+                    <label class="uk-form-label" for="form-password-icon">Password icon. Notice the quotes: <pre><code>data-uk-form-password='{lblShow: "&lt;i class=\"uk-icon-eye\"&gt;&lt;/i&gt;", lblHide: "&lt;i class=\"uk-icon-eye-slash\"&gt;&lt;/i&gt;"}'</code></pre></label>
+                    <div class="uk-form-controls">
+                        <div class="uk-form-password">
+                            <input id="form-password-icon" type="password">
+                            <a href="" class="uk-form-password-toggle" data-uk-form-password='{lblShow: "<i class=\"uk-icon-eye\"></i>", lblHide: "<i class=\"uk-icon-eye-slash\"></i>"}'>
+                                <i class="uk-icon-eye"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
             </form>
 
         </div>


### PR DESCRIPTION
Allows html in the custom label. There might be a usability issue with the markup though. The data attribute has to be in single quotes, and the value in double quotes, slashing the doubles in the html.
`data-uk-form-password='{lblShow: "<i class=\"uk-icon-eye\"></i>", lblHide: "<i class=\"uk-icon-eye-slash\"></i>"}'`