### PR TITLE
Sortable "change" not working anymore

### DIFF
--- a/src/js/components/sortable.js
+++ b/src/js/components/sortable.js
@@ -473,6 +473,8 @@
         },
 
         triggerChangeEvents: function() {
+         
+            var $this = this;
 
             // trigger events once
             if (!currentlyDraggingElement) return;
@@ -490,6 +492,7 @@
             }
 
             triggers.forEach(function (trigger, i) {
+                $this.options.change(this, currentlyDraggingElement);
                 trigger.el.trigger('change.uk.sortable', [trigger.el, currentlyDraggingElement, trigger.mode]);
             });
         },


### PR DESCRIPTION
Regression introduced in this commit, https://github.com/uikit/uikit/commit/88ee3bd1f1b356eedf752cf4d4755e95395b5f27, change event not working enymore.

var sortable = UIkit.sortable($('#element'), {
    change: function () {
        alert('changed');  
    }
});

Not working
