### PR TITLE
description list horizontal with line

### DIFF
--- a/src/less/core/description-list.less
+++ b/src/less/core/description-list.less
@@ -45,6 +45,18 @@
 
     .uk-description-list-horizontal > dd { margin-left: @description-list-horizontal-margin-left; }
 
+    /* Modifier: `uk-description-list-line`
+     ========================================================================== */
+    .uk-description-list-horizontal.uk-description-list-line > dd {
+        margin-left: @description-list-horizontal-width;
+        padding-left: (@description-list-horizontal-margin-left - @description-list-horizontal-width);
+    }
+    .uk-description-list-horizontal.uk-description-list-line > dd:nth-child(n+3)  {
+        margin-top: @description-list-line-margin-top;
+        padding-top: @description-list-line-margin-top;
+        border-top: @description-list-line-border-width solid @description-list-line-border;
+    }
+
 }
 
 

--- a/tests/core/description-list.html
+++ b/tests/core/description-list.html
@@ -37,6 +37,19 @@
 
             </div>
 
+            <div class="uk-grid" data-uk-grid-margin>
+
+                    <dl class="uk-description-list uk-description-list-horizontal uk-description-list-line uk-width-medium-1-2">
+                        <dt>Description lists</dt>
+                        <dd>A description list defines terms and their corresponding descriptions.</dd>
+                        <dt>Lorem ipsum</dt>
+                        <dd>Dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</dd>
+                        <dt>A long term is truncated</dt>
+                        <dd>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</dd>
+                    </dl>
+
+            </div>
+
         </div>
 
     </body>


### PR DESCRIPTION
The combination of `uk-description-list-horizontal` and `uk-description-list-line` results in a list with only lines between the `dt` elements:
![image](https://cloud.githubusercontent.com/assets/5442402/8240929/7f155c66-1606-11e5-8536-3ebc2d367055.png)
The list gets crooked because the `dd`s lack margin and stack up to the top.

This PR solves that by adding the margin and border to the `dd` as well when both  `uk-description-list-horizontal` and `uk-description-list-line` are used on the `dl`.
![image](https://cloud.githubusercontent.com/assets/5442402/8240985/c1d2b99a-1606-11e5-9b2f-4fc89b730202.png)
