### PR TITLE
Update sticky.js

### DIFF
--- a/src/js/components/sticky.js
+++ b/src/js/components/sticky.js
@@ -224,7 +224,7 @@
 
                 if (sticky.boundary && sticky.boundary.length) {
 
-                    var bTop = sticky.boundary.position().top;
+                    var bTop = sticky.boundary.offset().top;
 
                     if (sticky.boundtoparent) {
                         containerBottom = documentHeight - (bTop + sticky.boundary.outerHeight()) + parseInt(sticky.boundary.css('padding-bottom'));


### PR DESCRIPTION
Use offset() instead of position() to calculate the offset of the boundary.

I'm not sure if this should be changed in that way, but it solved the problem that i had with a relative positioned div container.
#1344