### PR TITLE
Tooltip fix

### DIFF
--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -27,11 +27,10 @@
             "delay": 0, // in miliseconds
             "cls": "",
             "activeClass": "uk-active",
-            "src": function(ele, title) {
+            "src": function(ele) {
+                var title = ele.attr('title');
 
-                title = ele.attr('title');
-
-                if (title) {
+                if (title !== undefined) {
                     ele.data('cached-title', title).removeAttr('title');
                 }
 


### PR DESCRIPTION
Fix error when tooltips with empty (but present) title, introduced in 4db3a9c.

Also unnecessary argument `title` is not a local variable.