### PR TITLE
Buttons rounding improvements

### DIFF
--- a/themes/almost-flat/button.less
+++ b/themes/almost-flat/button.less
@@ -158,22 +158,22 @@
      * Reset border-radius
      */
 
-    .uk-button-group > .uk-button:not(:first-child):not(:last-child),
-    .uk-button-group > div:not(:first-child):not(:last-child) .uk-button {
+    .uk-button-group > .uk-button:not(:first-of-type):not(:last-of-type),
+    .uk-button-group > div:not(:first-of-type):not(:last-of-type) .uk-button {
         border-left-color: rgba(0,0,0,0.1);
         border-right-color: rgba(0,0,0,0.1);
         border-radius: 0;
     }
 
-    .uk-button-group > .uk-button:first-child,
-    .uk-button-group > div:first-child .uk-button {
+    .uk-button-group > .uk-button:first-of-type,
+    .uk-button-group > div:first-of-type .uk-button {
         border-right-color: rgba(0,0,0,0.1);
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
 
-    .uk-button-group > .uk-button:last-child,
-    .uk-button-group > div:last-child .uk-button {
+    .uk-button-group > .uk-button:last-of-type,
+    .uk-button-group > div:last-of-type .uk-button {
         border-left-color: rgba(0,0,0,0.1);
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
@@ -183,8 +183,8 @@
      * Collapse border
      */
 
-    .uk-button-group > .uk-button:nth-child(n+2),
-    .uk-button-group > div:nth-child(n+2) .uk-button { margin-left: -1px; }
+    .uk-button-group > .uk-button:nth-of-type(n+2),
+    .uk-button-group > div:nth-of-type(n+2) .uk-button { margin-left: -1px; }
 
     /*
      * Create position context to superimpose the successor elements border

--- a/themes/gradient/button.less
+++ b/themes/gradient/button.less
@@ -213,17 +213,17 @@
      * Reset border-radius
      */
 
-    .uk-button-group > .uk-button:not(:first-child):not(:last-child),
-    .uk-button-group > div:not(:first-child):not(:last-child) .uk-button { border-radius: 0; }
+    .uk-button-group > .uk-button:not(:first-of-type):not(:last-of-type),
+    .uk-button-group > div:not(:first-of-type):not(:last-of-type) .uk-button { border-radius: 0; }
 
-    .uk-button-group > .uk-button:first-child,
-    .uk-button-group > div:first-child .uk-button {
+    .uk-button-group > .uk-button:first-of-type,
+    .uk-button-group > div:first-of-type .uk-button {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
 
-    .uk-button-group > .uk-button:last-child,
-    .uk-button-group > div:last-child .uk-button {
+    .uk-button-group > .uk-button:last-of-type,
+    .uk-button-group > div:last-of-type .uk-button {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }
@@ -232,8 +232,8 @@
      * Collapse border
      */
 
-    .uk-button-group > .uk-button:nth-child(n+2),
-    .uk-button-group > div:nth-child(n+2) .uk-button { margin-left: -1px; }
+    .uk-button-group > .uk-button:nth-of-type(n+2),
+    .uk-button-group > div:nth-of-type(n+2) .uk-button { margin-left: -1px; }
 
     /*
      * Create position context to superimpose the successor elements border


### PR DESCRIPTION
`*-child` often is not what we really want, `*-of-type` is better choice here.
For instance, I'm using [Polymer](https://www.polymer-project.org/1.0/) and sometimes have `<template>` elements within DOM structure

![2015-06-29 18-38-29](https://cloud.githubusercontent.com/assets/928965/8413116/7dba17f4-1e8e-11e5-89af-4a9cce776940.png)

which breaks buttons rounding, patch solves this issue.