### PR TITLE
Git Ignore add /docs/css/uikit.docs.min.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist
 /docs/fonts/ProximaNova-Light-webfont.*
 /docs/fonts/ProximaNova-Reg-webfont.*
+/docs/css/uikit.docs.min.css
 /node_modules
 /showcase
 /tools

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ var watchmode    = gutil.env._.length && gutil.env._[0] == 'watch',
     ];
 
 
-gulp.task('default', ['dist', 'build-docs', 'indexthemes'], function(done) {
+gulp.task('default', ['dist', 'indexthemes'], function(done) {
 
     if(gutil.env.p || gutil.env.prefix) {
         runSequence('prefix', function(){


### PR DESCRIPTION
When running gulp (default), it calls build docs, which updates docs/css/uikit.docs.min.css .  This behavior is problematic when trying to merge with the upstream. Very few users need to rebuild the documentation css. Instead, contribuitors can call "gulp build-docs" manually.