### PR TITLE
Fixing docs.min.css error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist
 /docs/fonts/ProximaNova-Light-webfont.*
 /docs/fonts/ProximaNova-Reg-webfont.*
+/docs/css/uikit.docs.min.css
 /node_modules
 /showcase
 /tools

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ var watchmode    = gutil.env._.length && gutil.env._[0] == 'watch',
     ];
 
 
-gulp.task('default', ['dist', 'build-docs', 'indexthemes'], function(done) {
+gulp.task('default', ['dist', 'indexthemes'], function(done) {
 
     if(gutil.env.p || gutil.env.prefix) {
         runSequence('prefix', function(){


### PR DESCRIPTION
I have forked UIkit to create a new theme, but I also want to merge changes upstream.  In running the default gulp command, it regenerates the doc css, which should not be the default behavior.  Instead, this command should only be done manually, as very few users actually need to update its functionality.