### PR TITLE
Datepicker 'current' value on change event and some cleanup

### DIFF
--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -195,8 +195,7 @@
                     if (ele.is('[data-date]')) {
                         active.current = moment(ele.data("date"));
                         active.element.val(active.current.format(active.options.format)).trigger("change");
-                        dropdown.hide();
-                        active = false;
+                        active.hide();
                     } else {
                        active.add(1 * (ele.hasClass("uk-datepicker-next") ? 1:-1), "months");
                     }

--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -193,7 +193,8 @@
                     if (ele.hasClass('uk-datepicker-date-disabled')) return false;
 
                     if (ele.is('[data-date]')) {
-                        active.element.val(moment(ele.data("date")).format(active.options.format)).trigger("change");
+                        active.current = moment(ele.data("date"));
+                        active.element.val(active.current.format(active.options.format)).trigger("change");
                         dropdown.hide();
                         active = false;
                     } else {

--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -187,7 +187,7 @@
                         active.element.val(active.current.format(active.options.format)).trigger("change");
                         active.hide();
                     } else {
-                       active.add(1 * (ele.hasClass("uk-datepicker-next") ? 1:-1), "months");
+                       active.add((ele.hasClass("uk-datepicker-next") ? 1:-1), "months");
                     }
                 });
 

--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -36,15 +36,7 @@
             pos: 'auto',
             template: function(data, opts) {
 
-                var content = '', maxDate, minDate, i;
-
-                if (opts.maxDate!==false){
-                    maxDate = isNaN(opts.maxDate) ? moment(opts.maxDate, opts.format) : moment().add(opts.maxDate, 'days');
-                }
-
-                if (opts.minDate!==false){
-                    minDate = isNaN(opts.minDate) ? moment(opts.minDate, opts.format) : moment().add(opts.minDate-1, 'days');
-                }
+                var content = '', i;
 
                 content += '<div class="uk-datepicker-nav">';
                 content += '<a href="" class="uk-datepicker-previous"></a>';
@@ -68,8 +60,8 @@
 
                     options = [];
 
-                    minYear = minDate ? minDate.year() : currentyear - 50;
-                    maxYear = maxDate ? maxDate.year() : currentyear + 20;
+                    minYear = data.minDate ? data.minDate.year() : currentyear - 50;
+                    maxYear = data.maxDate ? data.maxDate.year() : currentyear + 20;
 
                     for (i=minYear;i<=maxYear;i++) {
                         if (i == data.year) {
@@ -109,9 +101,7 @@
 
                                 if(!day.inmonth) cls.push("uk-datepicker-table-muted");
                                 if(day.selected) cls.push("uk-active");
-
-                                if (maxDate && day.day > maxDate) cls.push('uk-datepicker-date-disabled uk-datepicker-table-muted');
-                                if (minDate && minDate > day.day) cls.push('uk-datepicker-date-disabled uk-datepicker-table-muted');
+                                if(day.disabled) cls.push('uk-datepicker-date-disabled uk-datepicker-table-muted');
 
                                 content += '<td><a href="" class="'+cls.join(" ")+'" data-date="'+day.day.format()+'">'+day.day.format("D")+'</a></td>';
                             }
@@ -274,8 +264,16 @@
                 now    = moment().format('YYYY-MM-DD'),
                 days   = [31, (year % 4 === 0 && year % 100 !== 0 || year % 400 === 0) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month],
                 before = new Date(year, month, 1).getDay(),
-                data   = {"month":month, "year":year,"weekdays":[],"days":[]},
+                data   = {"month":month, "year":year,"weekdays":[],"days":[], "maxDate": false, "minDate": false},
                 row    = [];
+
+            if (opts.maxDate!==false){
+                data.maxDate = isNaN(opts.maxDate) ? moment(opts.maxDate, opts.format) : moment().add(opts.maxDate, 'days');
+            }
+
+            if (opts.minDate!==false){
+                data.minDate = isNaN(opts.minDate) ? moment(opts.minDate, opts.format) : moment().add(opts.minDate-1, 'days');
+            }
 
             data.weekdays = (function(){
 
@@ -311,7 +309,7 @@
             for (var i = 0, r = 0; i < cells; i++) {
 
                 day        = new Date(year, month, 1 + (i - before));
-                isDisabled = (opts.mindate && day < opts.mindate) || (opts.maxdate && day > opts.maxdate);
+                isDisabled = (data.minDate && data.minDate > day) || (data.maxDate && day > data.maxDate);
                 isInMonth  = !(i < before || i >= (days + before));
 
                 day = moment(day);

--- a/tests/components/datepicker.html
+++ b/tests/components/datepicker.html
@@ -43,6 +43,23 @@
                 </div>
 
                 <div class="uk-form-row">
+                    <script>
+                        UIkit.ready(function () {
+                            var date1 = UIkit.datepicker(UIkit.$('#date1'));
+                            date1.on('change.uk.datepicker', function () {
+                                UIkit.$('#output-date1').text(date1.current.format('DD.MM.YYYY'));
+                            });
+                        });
+                    </script>
+
+                    <label class="uk-form-label" for="form-date">Date</label>
+                    <div class="uk-form-controls">
+                        <input type="text" data-uk-datepicker="{format:'DD-MM-YYYY'}" id="date1">
+                        <p class="uk-form-help-block">Value <code>this.current</code> after 'change' event: <span id="output-date1"></span></p>
+                    </div>
+                </div>
+
+                <div class="uk-form-row">
                     <label class="uk-form-label" for="form-date">Date</label>
                     <div class="uk-form-controls">
                         <input type="text" data-uk-datepicker="{format:'DD.MM.YYYY', pos: 'top'}">


### PR DESCRIPTION
-When listening to the `change` event on a datepicker, you'd have to retrieve the current value from the DOM, even when you have the datepicker instance at hand. This PM sets the value of `this.current` to the selected date.
-I also used the default `hide()` function from the datepicker, so that the `hide.uk.datepicker` event is triggered.
-The existing logic for mindate/maxdate in the `getRows()` function did not work, instead that logic was done in the template function. I moved the working part to the `getRows()` function, since that seems to make more sense.
-I don't think `(ele.hasClass("uk-datepicker-next") ? 1:-1)` could ever be a non-integer value, why multiply it by 1?
