### PR TITLE
Ignore `<template>` elements in switcher

### DIFF
--- a/src/js/core/switcher.js
+++ b/src/js/core/switcher.js
@@ -50,7 +50,7 @@
                 if (this.connect.length) {
 
                     // Init ARIA for connect
-                    this.connect.children().attr('aria-hidden', 'true');
+                    this.connect.children(':not(template)').attr('aria-hidden', 'true');
 
                     this.connect.on("click", '[data-uk-switcher-item]', function(e) {
 
@@ -161,7 +161,7 @@
                 this.connect.each(function() {
 
                     var container = UI.$(this),
-                        children  = UI.$(container.children()),
+                        children  = UI.$(container.children(':not(template)')),
                         current   = UI.$(children.filter('.uk-active')),
                         next      = UI.$(children.eq($this.index));
 


### PR DESCRIPTION
`<template>` elements are a bit special and are used, for instance, by Polymer for loops in Web Components templates, after which `<template>` remains to be in DOM alongside with normal elements.
Since `<template>` elements are never intended to be used for real content directly visible to user we need to ignore it.