### PR TITLE
Tabs a no href

### DIFF
--- a/src/js/core/tab.js
+++ b/src/js/core/tab.js
@@ -147,7 +147,7 @@
 
                         if (!item.hasClass('uk-disabled')) {
 
-                            clone = item[0].outerHTML.replace('<a ', '<a data-index="'+i+'" ');
+                            clone = item[0].outerHTML.replace('<a', '<a data-index="'+i+'"');
 
                             this.responsivetab.lst.append(clone);
                         }


### PR DESCRIPTION
Assumption that `.uk-tab > li > a` has any attributes is wrong, it is not always the case, since switching is done using order index instead of `href` attribute