### PR TITLE
Publish /dist/ files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+/.idea
+/custom
+/docs/fonts/ProximaNova-Light-webfont.*
+/docs/fonts/ProximaNova-Reg-webfont.*
+/node_modules
+/showcase
+/tools
+*~
+*.diff
+*.patch
+.DS_Store
+.project
+.settings
+themes.json

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
       "url": "https://github.com/uikit/uikit/blob/master/LICENSE.md"
     }
   ],
+  "scripts": {
+    "prepublish": "gulp"
+  },
   "dependencies": {
     "node-promise": "^0.5.10"
   },


### PR DESCRIPTION
This allows webpack/browserify users to consume uikit via npm, e.g. with webpack:

```js
// webpack.config.js
var webpack = require('webpack');

module.exports = {
  ...
  plugins: [
    // Provide jQuery to legacy modules (e.g. uikit)
    new webpack.ProvidePlugin({
      jQuery: 'jquery',
      'window.jQuery': 'jquery'
    })
  ],
  ...
};
```

```js
// somefile.js
var UIkit = require('uikit/dist/js/uikit');
```

Using [ProvidePlugin](http://webpack.github.io/docs/list-of-plugins.html#provideplugin) since uikit expects a global `jQuery` variable.

---

This is a bit of a stop gap measure until UIkit truly supports CommonJS environments (https://github.com/uikit/uikit/issues/742)