### PR TITLE
Offcanvas as overlay layer

### DIFF
--- a/src/js/core/offcanvas.js
+++ b/src/js/core/offcanvas.js
@@ -18,6 +18,7 @@
                 bar       = element.find(".uk-offcanvas-bar:first"),
                 rtl       = (UI.langdirection == "right"),
                 flip      = bar.hasClass("uk-offcanvas-bar-flip") ? -1:1,
+                over      = bar.hasClass("uk-offcanvas-bar-over"),
                 dir       = flip * (rtl ? -1 : 1);
 
             scrollpos = {x: window.pageXOffset, y: window.pageYOffset};
@@ -25,7 +26,9 @@
             element.addClass("uk-active");
 
             $body.css({"width": window.innerWidth, "height": window.innerHeight}).addClass("uk-offcanvas-page");
-            $body.css((rtl ? "margin-right" : "margin-left"), (rtl ? -1 : 1) * (bar.outerWidth() * dir)).width(); // .width() - force redraw
+            if (!over) { 
+                $body.css((rtl ? "margin-right" : "margin-left"), (rtl ? -1 : 1) * (bar.outerWidth() * dir)).width(); // .width() - force redraw 
+            }
 
             $html.css('margin-top', scrollpos.y * -1);
 

--- a/src/less/core/offcanvas.less
+++ b/src/less/core/offcanvas.less
@@ -54,7 +54,7 @@
 
 .uk-offcanvas {
     /* 1 */
-    display: none;
+    visibility: hidden;
     /* 2 */
     position: fixed;
     top: 0;
@@ -69,7 +69,7 @@
     .hook-offcanvas;
 }
 
-.uk-offcanvas.uk-active { display: block; }
+.uk-offcanvas.uk-active { visibility: visible; }
 
 
 /* Sub-object `uk-offcanvas-page`


### PR DESCRIPTION
#1453, Having the ability to have off-canvas as an overlay can lead to more modern designs (Google Material Design) and as mentioned it can make the animation less choppy.

It’s a very quick and easy change, however to make this work with the animation I’ve had to change it from “display: none;” to “visibility: hidden;”.

What do you think about that? 