### PR TITLE
youtube lightbox sizing

### DIFF
--- a/src/js/components/lightbox.js
+++ b/src/js/components/lightbox.js
@@ -352,19 +352,25 @@
 
                     if(!cache[id]) {
 
-                        var img = new Image();
-
-                        img.onerror = function(){
-                            cache[id] = {width:640, height:320};
-                            resolve(id, cache[id].width, cache[id].height);
-                        };
+                        var img = new Image(), lowres = false;
 
                         img.onload = function(){
-                            cache[id] = {width:img.width, height:img.height};
-                            resolve(id, img.width, img.height);
+                            //youtube default 404 thumb, fall back to lowres
+                            if (img.width == 120 && img.height == 90) {
+                                if (!lowres) {
+                                    lowres = true;
+                                    img.src = '//img.youtube.com/vi/' + id + '/0.jpg';
+                                } else {
+                                    cache[id] = {width: 640, height: 320};
+                                    resolve(id, cache[id].width, cache[id].height);
+                                }
+                            } else {
+                                cache[id] = {width: img.width, height: img.height};
+                                resolve(id, img.width, img.height);
+                            }
                         };
 
-                        img.src = '//img.youtube.com/vi/'+id+'/0.jpg';
+                        img.src = '//img.youtube.com/vi/'+id+'/maxresdefault.jpg';
 
                     } else {
                         resolve(id, cache[id].width, cache[id].height);


### PR DESCRIPTION
The size of the lightbox a Youtube video is shown in, is determined by the size of the default preview image youtube serves under the url `'//img.youtube.com/vi/'+id+'/0.jpg'`, usually 480x360 pixels (See [SO](http://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api/20542029#20542029)). This causes the lightbox never to be bigger than that.
Many users request bigger Youtube lightboxes, and it can be done.
On high resolution videos the `'//img.youtube.com/vi/'+id+'/maxresdefault.jpg'` image provides a full res image if available, making it possible to create bigger lightboxes. A fallback has to be provided, because not all videos have that image.

Which gives a new problem, as the fallback as it was in place does not actually work. Although returning a 404 status on the request, Youtube serves a 120x90 placeholder image:
![image](https://cloud.githubusercontent.com/assets/5442402/9428177/c1eb4a58-49a2-11e5-9497-2802cd8960d5.png)
The img.onerror callback does not trigger! So the fallback checking is a bit nasty since we'd have to check the image size, rather than acting on a request status. Maybe the image can be checked by doing an ajax request to the url, and checking the status, but then the image has to be loaded and measured again later, not sure if that will be a better way.
