### PR TITLE
Reduce gulpefile.js by automatically loading in gulp plugins.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-header": "1.0.5",
     "gulp-ignore": "^1.2.0",
     "gulp-less": "latest",
+    "gulp-load-plugins": "^0.10.0",
     "gulp-minify-css": "^1.1.1",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.4.0",


### PR DESCRIPTION
We can reduce the `gulpfile.js` by making use of `gulp-load-plugins`.

Any plugin beginning with `gulp-*` will be automatically be assigned to `$`. Then call the plugin by it's name: `$.pluginName`.

Plugins containing hypens in their names will have their hypens dropped and renamed using camel case. For example: `gulp-minify-css` -> `minifyCss`.
