### PR TITLE
Make UIkit integrate a little more cleanly with NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+/.idea
+/custom
+/docs/fonts/ProximaNova-Light-webfont.*
+/docs/fonts/ProximaNova-Reg-webfont.*
+/node_modules
+/showcase
+/tools
+*~
+*.diff
+*.patch
+.DS_Store
+.project
+.settings
+themes.json

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+
   "name": "uikit",
   "title": "UIkit",
   "description": "UIkit is a lightweight and modular front-end framework for developing fast and powerful web interfaces.",
@@ -22,6 +22,7 @@
   "scripts": {
     "prepublish": "gulp"
   },
+  "main": "dist/js/uikit.js",
   "dependencies": {
     "node-promise": "^0.5.10"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
       "url": "https://github.com/uikit/uikit/blob/master/LICENSE.md"
     }
   ],
+  "scripts": {
+    "prepublish": "gulp"
+  },
   "dependencies": {
     "node-promise": "^0.5.10"
   },


### PR DESCRIPTION
This should make life easier for people using browserify, webpack or (in my case) JSPM/SystemJS.  This still doesn't solve the need for `window.jQuery`, but by publishing `dist` and including a `main:`, people like me can `require('uikit')` and everything should just work.

This branch includes an [earlier PR](https://github.com/uikit/uikit/pull/1434) (raised by @elliottsj).  It also adds the `main` attribute to `package.json`.

I'm raising as a new PR as the `CONTRIBUTING.md` says to open a PR into `develop`, rather than `master`.