### PR TITLE
[=] Fix hiding dropdown on click with option `mode:'hover'` for dropdown or items with class `uk-dropdown-close`

### DIFF
--- a/docs/dropdown.html
+++ b/docs/dropdown.html
@@ -1042,6 +1042,12 @@
 });
 </code></pre>
 
+                            <hr class="uk-article-divider">
+
+                            <h2 id="css-options"><a href="#css-options" class="uk-link-reset">CSS options</a></h2>
+
+                            <p>Add class <code>.uk-dropdown-close</code> to dropdown container or to item to hide dropdown when user click on item.</p>
+
                         </article>
 
                     </div>

--- a/src/js/core/dropdown.js
+++ b/src/js/core/dropdown.js
@@ -139,6 +139,9 @@
                     }
 
                     if (active && active == $this) {
+                        if (!$this.dropdown.find(e.target).length || $target.is(".uk-dropdown-close") || $target.parents(".uk-dropdown-close").length) {
+                            $this.hide();
+                        }
                         return;
                     }
 


### PR DESCRIPTION
If use for dropdown option `mode:'click'` - dropdown is hiding after
user's click. But if this option 'hover' - it not hides. This commit is
fixing this problem.