### PR TITLE
Add missing type in the datepicker markup example

### DIFF
--- a/docs/datepicker.html
+++ b/docs/datepicker.html
@@ -105,7 +105,7 @@
                             <h3 class="tm-article-subtitle">Markup</h3>
 
 <pre><code>&lt;form class="uk-form"&gt;
-    &lt;input type="" data-uk-datepicker="{format:'DD.MM.YYYY'}"&gt;
+    &lt;input type="text" data-uk-datepicker="{format:'DD.MM.YYYY'}"&gt;
 &lt;/form&gt;</code></pre>
 
                             <hr class="uk-article-divider">


### PR DESCRIPTION
I was trying to use the datepicker and it took my a while to understand why the element was not displayed properly.