### PR TITLE
fix for slider not showing the last element

### DIFF
--- a/src/js/components/slider.js
+++ b/src/js/components/slider.js
@@ -268,13 +268,22 @@
 
                                 area += this.items.eq(i).data('width');
 
-                                if (area >= this.vp) {
+                                if (area == this.vp) {
                                     idx = i;
+                                    break;
+                                }
+
+                                if (area > this.vp) {
+                                    idx = (i < this.items.length-1) ? i+1 : i;
                                     break;
                                 }
                             }
 
-                            this.updatePos(this.items.eq(idx).data('left')*-1);
+                            if (area > this.vp) {
+                                this.updatePos((this.container.width() - this.vp) * -1);
+                            } else {
+                                this.updatePos(this.items.eq(idx).data('left')*-1);
+                            }
                         }
                     }
                 }

--- a/tests/components/slider.html
+++ b/tests/components/slider.html
@@ -260,6 +260,26 @@
 
             </div>
 
+            <h3>No infinite</h3>
+
+            <div class="uk-slidenav-position uk-margin" data-uk-slider="{infinite:false}">
+
+                <div class="uk-slider-container">
+                    <ul class="uk-slider">
+                        <li class="uk-width-1-3"><img src="holder.js/400x200/sky/auto/text:1/size:100" width="400" height="200" alt=""></li>
+                        <li class="uk-width-1-5"><img src="holder.js/240x200/vine/auto/text:2/size:100" width="240" height="200" alt=""></li>
+                        <li class="uk-width-2-5"><img src="holder.js/480x200/lava/auto/text:3/size:100" width="480" height="200" alt=""></li>
+                        <li class="uk-width-1-4"><img src="holder.js/300x200/sky/auto/text:4/size:100" width="300" height="200" alt=""></li>
+                        <li class="uk-width-1-3"><img src="holder.js/400x200/vine/auto/text:5/size:100" width="400" height="200" alt=""></li>
+                        <li class="uk-width-1-5"><img src="holder.js/240x200/lava/auto/text:6/size:100" width="240" height="200" alt=""></li>
+                    </ul>
+                </div>
+
+                <a href="#" class="uk-slidenav uk-slidenav-contrast uk-slidenav-previous" data-uk-slider-item="previous"></a>
+                <a href="#" class="uk-slidenav uk-slidenav-contrast uk-slidenav-next" data-uk-slider-item="next"></a>
+
+            </div>
+
             <h2>Background Images + Fullscreen</h2>
 
         </div>


### PR DESCRIPTION
Using the slider with infinite:false and elements with custom widths inside, did not show the last element fully, when it did not fit into the viewport. Here is an example of the bug:

http://codepen.io/anon/pen/vNGooG?editors=100

As you can see, element Nr. 6 is not fully shown, because the slider does not want to move element nr 4 in focus, because nr 3 would than be cut off. But I would say: better cut one off, you have already seen, than not showing the last one. What do you think?

So in this fix, the last element will be fully shown (in this case nr. 6), the focus will be moved to the next element (in this case nr. 4) and the element on the left will be cut off (in this case nr. 3).

Includes a test for this case as well.