### PR TITLE
adds maxHeight option for slideshow

### DIFF
--- a/docs/slideshow.html
+++ b/docs/slideshow.html
@@ -615,6 +615,11 @@
                                             <td>Defines the slideshow height.</td>
                                         </tr>
                                         <tr>
+                                            <td><code>maxHeight</code></td>
+                                            <td>false</td>
+                                            <td>The slideshow's height will never exceed this value.</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>start</code></td>
                                             <td>0</td>
                                             <td>Defines the first slideshow item to be displayed.</td>

--- a/src/js/components/slideshow.js
+++ b/src/js/components/slideshow.js
@@ -24,6 +24,7 @@
             animation          : "fade",
             duration           : 500,
             height             : "auto",
+            maxHeight          : false,
             start              : 0,
             autoplay           : false,
             autoplayInterval   : 7000,
@@ -265,6 +266,10 @@
                 this.slides.css('height', '').each(function() {
                     height = Math.max(height, UI.$(this).height());
                 });
+            }
+
+            if (height > this.options.maxHeight && this.options.maxHeight !== false) {
+                height = this.options.maxHeight;
             }
 
             this.container.css('height', height);


### PR DESCRIPTION
I think the height-option of the slideshow kind of restricts me when using the same slideshow settings for different contents. It always sets the slideshow to a specific height. But perhaps my content is this time smaller than the given height. Then I would like the slideshow to be smaller as well instead of scaling the content up to fit.

So I added an option for this case: maxHeight. The slideshow's height will never exceed this value. And if the calculated height is smaller, it will let the slideshow be smaller.