### PR TITLE
ignore keydown event when dropdown not visible

### DIFF
--- a/src/js/components/autocomplete.js
+++ b/src/js/components/autocomplete.js
@@ -89,7 +89,7 @@
             this.input.on({
                 "keydown": function(e) {
 
-                    if (e && e.which && !e.shiftKey) {
+                    if (e && e.which && !e.shiftKey && $this.visible) {
 
                         switch (e.which) {
                             case 13: // enter


### PR DESCRIPTION
When the autocomplete dropdown menu is not visible, the keydown events (for example, enter, up and down) should be ignored, as the user would *not* expect those keydown events are still associated with the hidden dropdown menu.