### PR TITLE
Hide suggestion list when no data to display

### DIFF
--- a/src/js/components/autocomplete.js
+++ b/src/js/components/autocomplete.js
@@ -204,6 +204,8 @@
                 this.input.val(data.value).trigger('change');
             }
 
+            this.value = this.input.val();
+
             this.hide();
         },
 

--- a/src/js/components/autocomplete.js
+++ b/src/js/components/autocomplete.js
@@ -323,6 +323,8 @@
                 this.show();
 
                 this.trigger('show.uk.autocomplete');
+            } else {
+                this.hide();
             }
 
             return this;


### PR DESCRIPTION
1) Suggestion list should be hidden if no data is being passed to the render function. This happens when source type is 'object' and none of the source items match the `item.value && item.value.toLowerCase().indexOf($this.value.toLowerCase())!=-1` condition in the request function. Users should not see an empty list.

2) The 'value' property is not being updated on selection (enter or mousedown). If user focuses on the input field again after selection and hit enter, the suggestion list will be displayed (because this.value is outdated and request() will be called in the handle function).
