### PR TITLE
#Fix slider javascript parameter docs

### DIFF
--- a/docs/slider.html
+++ b/docs/slider.html
@@ -424,8 +424,8 @@
                                         </tr>
                                         <tr>
                                             <td><code>autoplay</code></td>
-                                            <td>false</td>
                                             <td>boolean</td>
+                                            <td>false</td>
                                             <td>Defines whether or not the slider items should switch automatically</td>
                                         </tr>
                                         </tr>

--- a/docs/slider.html
+++ b/docs/slider.html
@@ -406,8 +406,8 @@
                                         </tr>
                                         <tr>
                                             <td><code>threshold</code></td>
-                                            <td>boolean</td>
-                                            <td>true</td>
+                                            <td>integer</td>
+                                            <td>10</td>
                                             <td>Mouse movement threshold in pixel until trigger element dragging</td>
                                         </tr>
                                         <tr>


### PR DESCRIPTION
`threshold` was defined as boolean, but is integer

I also updated the corresponding default value of 10px

`autoplay` has mixed up table cells (default ↔ possible values)