### PR TITLE
AJAX-ifying pagination

### DIFF
--- a/src/js/components/pagination.js
+++ b/src/js/components/pagination.js
@@ -56,7 +56,7 @@
             this.currentPage   = this.options.currentPage;
             this.halfDisplayed = this.options.displayedPages / 2;
 
-            this.on("click", "a[data-page]", function(e){
+            this.off("click").on("click", "a[data-page]", function(e){
                 e.preventDefault();
                 $this.selectPage(UI.$(this).data("page"));
             });
@@ -76,7 +76,12 @@
             this.pages = pages ? pages : this.pages;
             this._render();
         },
+        reset: function(pageIndex, pages) {
+            this.currentPage = pageIndex;
+            this.render(pages);
 
+            this.options.onSelectPage.apply(this, [pageIndex]);
+        },
         selectPage: function(pageIndex, pages) {
             this.currentPage = pageIndex;
             this.render(pages);


### PR DESCRIPTION
Unbinding click events to pagination links before binding them prevents those events from bubbling up in the DOM every time the pagination component is re-inited after ajax data has been pulled and pages have to be redrawn. Now I know we could use pagination.render(new_total_pages) but I could't find a way to set the current page to the first one.

Also I added a reset function to re-init() the plugin without triggering a onSelectPage event
