### PR TITLE
Include topoffset in scrollspy target calculation

### DIFF
--- a/src/js/core/scrollspy.js
+++ b/src/js/core/scrollspy.js
@@ -169,7 +169,7 @@
                         scrollTop = $win.scrollTop(),
                         target = (function(){
                             for(var i=0; i< inviews.length;i++){
-                                if(inviews[i].offset().top >= scrollTop){
+                                if(inviews[i].offset().top - $this.options.topoffset >= scrollTop){
                                     return inviews[i];
                                 }
                             }


### PR DESCRIPTION
It doesn't seem like the topoffset option has the effect it should, it factors into the calculation in isInView but then is left out when looking for the target.