### PR TITLE
Fixed parallax for images with smaller width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Fixed Animated slideset filter
   - Fixed noDragClass option (sortable)
   - Fixed drop target detection (sortable)
+  - Fixed parallax for images with smaller width
 
 ### 2.24.3 (December 18, 2015)
 

--- a/src/js/components/parallax.js
+++ b/src/js/components/parallax.js
@@ -300,7 +300,7 @@
             h += extra;
             w += Math.ceil(extra * ratio);
 
-            if (w-extra > size.w && h < size.h) {
+            if (w-extra < size.w && h < size.h) {
                 return obj.element.css({'background-size': ''});
             }
 


### PR DESCRIPTION
Bug fix left and right bars when the image width is smaller then the element width.