### PR TITLE
Support for having a 'clear' function.

### DIFF
--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -184,7 +184,7 @@
 
                     if (ele.is('[data-date]')) {
                         active.current = moment(ele.data("date"));
-                        active.element.val(active.current.format(active.options.format)).trigger("change");
+                        active.element.val(active.current.isValid() ? active.current.format(active.options.format) : null).trigger("change");
                         active.hide();
                     } else {
                        active.add((ele.hasClass("uk-datepicker-next") ? 1:-1), "months");


### PR DESCRIPTION
When the data-date value does not resolve to a valid Date(), the value
set in the element is cleared.

It could be better to do this _only_ if [data-date=""], happy to change
to support that.