### PR TITLE
Added noChildrenClass to Nestable component

### DIFF
--- a/docs/nestable.html
+++ b/docs/nestable.html
@@ -469,6 +469,12 @@
                                             <td>Elements with this class will not trigger dragging. Useful when having the complete item draggable and not just the handle.</td>
                                         </tr>
                                         <tr>
+                                            <td><code>noChildrenClass</code></td>
+                                            <td>string</td>
+                                            <td>uk-nestable-nochildren</td>
+                                            <td>Elements with this class will not allow children. Useful for bottom-level items.</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>emptyClass</code></td>
                                             <td>string</td>
                                             <td>uk-nestable-empty</td>

--- a/src/js/components/nestable.js
+++ b/src/js/components/nestable.js
@@ -39,6 +39,7 @@
             listItemClass   : 'uk-nestable-item',
             dragClass       : 'uk-nestable-dragged',
             movingClass     : 'uk-nestable-moving',
+            noChildrenClass : 'uk-nestable-nochildren',
             emptyClass      : 'uk-nestable-empty',
             handleClass     : '',
             collapsedClass  : 'uk-collapsed',
@@ -490,8 +491,8 @@
                 mouse.distAxX = 0;
                 prev = this.placeEl.prev('li');
 
-                // increase horizontal level if previous sibling exists and is not collapsed
-                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass)) {
+                // increase horizontal level if previous sibling exists, is not collapsed, and does not have a 'no children' class
+                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass) && !prev.hasClass(opt.noChildrenClass)) {
 
                     // cannot increase level when item above is collapsed
                     list = prev.find(opt._listClass).last();


### PR DESCRIPTION
Useful for manually declaring items that shouldn't be nested, such as bottom-level items. It works well for me, and doesn't conflict with other nesting restrictions in my testing.