### PR TITLE
Timepicker: [bugfix?] display in grid, [enhancement] allow seconds

### DIFF
--- a/src/js/components/timepicker.js
+++ b/src/js/components/timepicker.js
@@ -55,9 +55,7 @@
             };
 
             if (this.element.is('input')) {
-                if (this.element.parent('.uk-autocomplete').length === 0) {
-                    this.element.wrap('<div class="uk-autocomplete"></div>');
-                }
+                this.element.wrap('<div class="uk-autocomplete"></div>');
                 container = this.element.parent();
             } else {
                 container = this.element.addClass('uk-autocomplete');

--- a/src/js/components/timepicker.js
+++ b/src/js/components/timepicker.js
@@ -55,7 +55,9 @@
             };
 
             if (this.element.is('input')) {
-                this.element.wrap('<div class="uk-autocomplete"></div>');
+                if (this.element.parent('.uk-autocomplete').length === 0) {
+                    this.element.wrap('<div class="uk-autocomplete"></div>');
+                }
                 container = this.element.parent();
             } else {
                 container = this.element.addClass('uk-autocomplete');

--- a/src/js/components/timepicker.js
+++ b/src/js/components/timepicker.js
@@ -20,10 +20,11 @@
     UI.component('timepicker', {
 
         defaults: {
-            format : '24h',
-            delay  : 0,
-            start  : 0,
-            end    : 24
+            format     : '24h',
+            delay      : 0,
+            start      : 0,
+            end        : 24,
+            showSeconds: false,
         },
 
         boot: function() {
@@ -45,7 +46,7 @@
 
         init: function() {
 
-            var $this  = this, times = getTimeRange(this.options.start, this.options.end), container;
+            var $this  = this, times = getTimeRange(this.options.start, this.options.end, this.options.showSeconds), container;
 
             this.options.minLength = 0;
             this.options.template  = '<ul class="uk-nav uk-nav-autocomplete uk-autocomplete-results">{{~items}}<li data-value="{{$item.value}}"><a>{{$item.value}}</a></li>{{/items}}</ul>';
@@ -87,7 +88,7 @@
 
         checkTime: function() {
 
-            var arr, timeArray, meridian = 'AM', hour, minute, time = this.autocomplete.input.val();
+            var arr, timeArray, meridian = 'AM', hour, minute, seconds, time = this.autocomplete.input.val();
 
             if (this.options.format == '12h') {
                 arr = time.split(' ');
@@ -97,11 +98,13 @@
                 timeArray = time.split(':');
             }
 
-            hour   = parseInt(timeArray[0], 10);
-            minute = parseInt(timeArray[1], 10);
+            hour    = parseInt(timeArray[0], 10);
+            minute  = parseInt(timeArray[1], 10);
+            seconds = this.options.showSeconds ? parseInt(timeArray[2], 10) : 0;
 
-            if (isNaN(hour))   hour = 0;
-            if (isNaN(minute)) minute = 0;
+            if (isNaN(hour))    hour = 0;
+            if (isNaN(minute))  minute = 0;
+            if (isNaN(seconds)) seconds = 0;
 
             if (this.options.format == '12h') {
                 if (hour > 12) {
@@ -134,25 +137,44 @@
             } else if (minute >= 60) {
                 minute = 0;
             }
+            
+            if (seconds < 0) {
+                seconds = 0;
+            } else if (seconds >= 60) {
+                seconds = 0;
+            }
 
-            this.autocomplete.input.val(this.formatTime(hour, minute, meridian)).trigger('change');
+            this.autocomplete.input.val(this.formatTime(hour, minute, meridian, seconds)).trigger('change');
         },
 
-        formatTime: function(hour, minute, meridian) {
+        formatTime: function(hour, minute, meridian, seconds) {
             hour = hour < 10 ? '0' + hour : hour;
             minute = minute < 10 ? '0' + minute : minute;
-            return hour + ':' + minute + (this.options.format == '12h' ? ' ' + meridian : '');
+            var time = hour + ':' + minute;
+            if (this.options.showSeconds) {
+                seconds = seconds < 10 ? '0' + seconds : seconds;
+                time += ':' + seconds;
+            }
+
+            return time + (this.options.format == '12h' ? ' ' + meridian : '');
         }
     });
 
     // helper
 
-    function getTimeRange(start, end) {
+    function getTimeRange(start, end, showSeconds) {
 
         start = start || 0;
         end   = end || 24;
 
         var times = {'12h':[], '24h':[]}, i, h;
+
+        var topHour      = showSeconds ? ':00:00' : ':00';
+        var topHourAM    = topHour + ' AM';
+        var topHourPM    = topHour + ' PM';
+        var bottomHour   = showSeconds ? ':30:00' : ':30';
+        var bottomHourAM = bottomHour + ' AM';
+        var bottomHourPM = bottomHour + ' PM';
 
         for (i = start, h=''; i<end; i++) {
 
@@ -160,18 +182,18 @@
 
             if (i<10)  h = '0'+h;
 
-            times['24h'].push({value: (h+':00')});
-            times['24h'].push({value: (h+':30')});
+            times['24h'].push({value: (h + topHour)});
+            times['24h'].push({value: (h + bottomHour)});
 
             if (i === 0) {
                 h = 12;
-                times['12h'].push({value: (h+':00 AM')});
-                times['12h'].push({value: (h+':30 AM')});
+                times['12h'].push({value: (h + topHourAM)});
+                times['12h'].push({value: (h + bottomHourAM)});
             }
 
             if (i > 0 && i<13 && i!==12) {
-                times['12h'].push({value: (h+':00 AM')});
-                times['12h'].push({value: (h+':30 AM')});
+                times['12h'].push({value: (h + topHourAM)});
+                times['12h'].push({value: (h + bottomHourAM)});
             }
 
             if (i >= 12) {
@@ -180,8 +202,8 @@
                 if (h === 0) h = 12;
                 if (h < 10) h = '0'+String(h);
 
-                times['12h'].push({value: (h+':00 PM')});
-                times['12h'].push({value: (h+':30 PM')});
+                times['12h'].push({value: (h + topHourPM)});
+                times['12h'].push({value: (h + bottomHourPM)});
             }
         }
 

--- a/src/less/components/autocomplete.less
+++ b/src/less/components/autocomplete.less
@@ -44,6 +44,10 @@
     vertical-align: middle;
 }
 
+/* Fix for .uk-autocomplete being a child of a div */
+div > .uk-autocomplete {
+    display: block;
+}
 
 /* Nav modifier `uk-nav-autocomplete`
  ========================================================================== */


### PR DESCRIPTION
Issue: When setting up a timepicker element in a grid, the element changes size when selected. I'm not a CSS expert, but displaying the .uk-autocomplete div as an inline-block within a column div (or possibly any other div) seems to be the culprit. See this fiddle for an example: https://jsfiddle.net/rb8gz29c

I updated the autocomplete stylesheet to display .uk-autocomplete as a block when it's a child of a div. Admittedly, I'm not sure how this would affect any deeper nesting.

My first solution required that the timepicker was pre-wrapped in a .uk-autocomplete. Then the autocomplete javascript was updated to wrap the timepicker if that .uk-autocomplete wasn't already there. 