### PR TITLE
[Bugfix?] Timepicker in grid layout

### DIFF
--- a/src/less/components/autocomplete.less
+++ b/src/less/components/autocomplete.less
@@ -44,6 +44,10 @@
     vertical-align: middle;
 }
 
+/* Fix for .uk-autocomplete being a child of a div */
+div > .uk-autocomplete {
+    display: block;
+}
 
 /* Nav modifier `uk-nav-autocomplete`
  ========================================================================== */


### PR DESCRIPTION
Issue: When setting up a timepicker element in a grid, the element changes size when selected. I'm not a CSS expert, but displaying the .uk-autocomplete div as an inline-block within a column div (or possibly any other div) seems to be the culprit. See this fiddle for an example: https://jsfiddle.net/rb8gz29c

I updated the autocomplete stylesheet to display .uk-autocomplete as a block when it's a child of a div. Admittedly, I'm not sure how this would affect any deeper nesting.
