### PR TITLE
 token.state is now boolean

### DIFF
--- a/src/js/components/htmleditor.js
+++ b/src/js/components/htmleditor.js
@@ -577,7 +577,7 @@
             editor.on('cursorMode', function(e, param) {
                 if (editor.editor.options.mode == 'gfm') {
                     var pos = editor.editor.getDoc().getCursor();
-                    if (!editor.editor.getTokenAt(pos).state.base.htmlState) {
+                    if (!editor.editor.getTokenAt(pos).state) {
                         param.mode = 'markdown';
                     }
                 }


### PR DESCRIPTION
new version of CodeMirror does not provide a state object anymore, just a bool.
No action was functional anymore.
