### PR TITLE
Fix where many requestanimationframes can exist

### DIFF
--- a/src/js/core/core.js
+++ b/src/js/core/core.js
@@ -644,7 +644,7 @@
             UI.component.bootComponents();
 
             // custom scroll observer
-            requestAnimationFrame((function(){
+            var rafToken = requestAnimationFrame((function(){
 
                 var memory = {dir: {x:0, y:0}, x: window.pageXOffset, y:window.pageYOffset};
 
@@ -671,7 +671,8 @@
                         }]);
                     }
 
-                    requestAnimationFrame(fn);
+                    cancelAnimationFrame(rafToken);
+                    rafToken = requestAnimationFrame(fn);
                 };
 
                 if (UI.support.touch) {


### PR DESCRIPTION
Always cancel any outstanding requestAnimationFrames before enqueuing another...

In iOS Safari, there can end up being hundreds and hundreds of requestAnimationFrames enqueued. This isn't ideal, as it can take 500ms+ to process them all in one frame.