### PR TITLE
fix(slideshow): only use first element as container

### DIFF
--- a/src/js/components/slideshow.js
+++ b/src/js/components/slideshow.js
@@ -66,7 +66,7 @@
 
             var $this = this, canvas, kbanimduration;
 
-            this.container     = this.element.hasClass('uk-slideshow') ? this.element : UI.$(this.find('.uk-slideshow'));
+            this.container     = this.element.hasClass('uk-slideshow') ? this.element : UI.$(this.find('.uk-slideshow:first'));
             this.slides        = this.container.children();
             this.slidesCount   = this.slides.length;
             this.current       = this.options.start;


### PR DESCRIPTION
Kind of an edge-case, but if you create a slideshow within a slideshow (whoever want's to do this ;)) the parent-slideshow also uses the slides of the child-slideshow. That means the parent slideshow tries to navigate through the slides of the child slideshow as well, resulting in an unexpected behavior.

Adding `:first` to the container-selector fixes this.