### PR TITLE
Documenting 'method' setting, adding 'headers' setting

### DIFF
--- a/docs/upload.html
+++ b/docs/upload.html
@@ -115,9 +115,15 @@
                                         bar         = progressbar.find('.uk-progress-bar'),
                                         settings    = {
 
+                                        method: 'PUT', // HTTP method, default is 'POST'
+
                                         action: '/', // upload url
 
                                         allow : '*.(jpg|gif|png)', // allow only images
+
+                                        headers: {
+                                            'Access-Control-Allow-Origin': '*'
+                                        },
 
                                         loadstart: function() {
                                             bar.css("width", "0%").text("0%");
@@ -221,6 +227,12 @@
                                     </thead>
                                     <tbody>
                                         <tr>
+                                            <td><code>method</code></td>
+                                            <td>string</td>
+                                            <td>POST</td>
+                                            <td>HTTP method used for the upload</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>action</code></td>
                                             <td>string</td>
                                             <td>''</td>
@@ -245,6 +257,12 @@
                                             <td>Additional request parameters</td>
                                         </tr>
                                         <tr>
+                                        <tr>
+                                            <td><code>headers</code></td>
+                                            <td>JSON Object</td>
+                                            <td>{}</td>
+                                            <td>Additional request headers</td>
+                                        </tr>
                                             <td><code>allow</code></td>
                                             <td>string</td>
                                             <td>*.*</td>

--- a/src/js/components/upload.js
+++ b/src/js/components/upload.js
@@ -187,6 +187,7 @@
             if (settings.type=="json") {
                 xhr.setRequestHeader("Accept", "application/json");
             }
+            for (var h in settings.headers) { xhr.setRequestHeader(h, settings.headers[h]); }
 
             xhr.onreadystatechange = function() {
 
@@ -221,6 +222,7 @@
         'allow' : '*.*',
         'type'  : 'text',
         'filelimit': false,
+        'headers': {},
 
         // events
         'before'          : function(o){},


### PR DESCRIPTION
I use file uploader component to directly upload files from web-browser to Rackspace Cloud. To achieve that I needed to use HTTP method "PUT" instead of default "POST". This already can be done, so I added this feature to documentation.

I also added a feature to specify additional headers, for example  'Access-Control-Allow-Origin', or auth token.

This addition will make using of file upload component more flexible.
