### PR TITLE
Fix for Dynamic Grid _getSize is not a function

### DIFF
--- a/src/js/components/grid.js
+++ b/src/js/components/grid.js
@@ -302,7 +302,7 @@
     * MIT license
     * https://github.com/desandro/get-size
     */
-    var _getSize = (function(){
+    function _getSize() {
 
         var prefixes = 'Webkit Moz ms Ms O'.split(' ');
         var docElemStyle = document.documentElement.style;
@@ -518,9 +518,9 @@
 
         return getSize;
 
-    })();
+    }
 
     function getElementSize(ele) {
-        return _getSize(ele);
+        return _getSize()(ele);
     }
 });


### PR DESCRIPTION
Here's a fix for Uncaught TypeError: _getSize is not a function.
Which is appear when using Dynamic grid.

Also this issue is described here: [https://github.com/uikit/uikit/issues/1905](url)