### PR TITLE
append id to notify message

### DIFF
--- a/src/js/components/notify.js
+++ b/src/js/components/notify.js
@@ -63,6 +63,12 @@
             this.element.addClass('uk-notify-message-'+this.options.status);
             this.currentstatus = this.options.status;
         }
+        
+        // id for closebutton
+        if (this.options.notifyhandle) {
+            this.element.attr('id' , this.options.notifyhandle);
+            this.currenthandle = this.options.notifyhandle;
+        }
 
         this.group = this.options.group;
 


### PR DESCRIPTION
appending dynamic id's to notify message for different close states when more than one notify message is shown.

use options to define the id for the notify message

```
UIkit.notify({
    notifyhandle: 'yournotificationhandle',
    message     : 'Bazinga!',
    status      : 'info',
    timeout     : 5000,
    pos         : 'top-center'
});
```
