### PR TITLE
Fix scroll top on modal opening

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -91,7 +91,7 @@
                 this.element.addClass("uk-open");
             }
 
-            $html.addClass("uk-modal-page").height(); // force browser engine redraw
+            $('body').addClass("uk-modal-page").height(); // force browser engine redraw
 
             // Update ARIA
             this.element.attr('aria-hidden', 'false');
@@ -183,7 +183,7 @@
             this.element.attr('aria-hidden', 'true');
 
             if (!activeCount) {
-                $html.removeClass('uk-modal-page');
+                $('body').removeClass("uk-modal-page");
                 body.css(this.paddingdir, "");
             }
 


### PR DESCRIPTION
This PR will fix scroll top on modal opening when body or html tag containing "uk-height-viewport" or "uk-height-1-1" class (issues #590 #1738 #1379 #991).

Changes tested on Firefox, Chrome, Opera, Opera Beta, IE and Edge with success.
