### PR TITLE
lightbox: add option for allowfullscreen

### DIFF
--- a/docs/lightbox.html
+++ b/docs/lightbox.html
@@ -192,6 +192,12 @@
                                             <td>Group name to group elements as a gallery to show</td>
                                         </tr>
                                         <tr>
+                                            <td><code>allowfullscreen</code></td>
+                                            <td>boolean</td>
+                                            <td>true</td>
+                                            <td>Whether embedded videos can toggle fullscreen or not (adds the <code>allowfullscreen</code> attribute to Iframes)</td>
+                                        </tr>
+                                        <tr>
                                             <td><code>duration</code></td>
                                             <td>integer</td>
                                             <td>400</td>

--- a/src/js/components/lightbox.js
+++ b/src/js/components/lightbox.js
@@ -21,9 +21,10 @@
     UI.component('lightbox', {
 
         defaults: {
-            "group"      : false,
-            "duration"   : 400,
-            "keyboard"   : true
+            "allowfullscreen" : true,
+            "duration"        : 400,
+            "group"           : false,
+            "keyboard"        : true
         },
 
         index : 0,
@@ -330,7 +331,7 @@
                 var id, matches, resolve = function(id, width, height) {
 
                     data.meta = {
-                        'content': '<iframe src="//www.youtube.com/embed/'+id+'" width="'+width+'" height="'+height+'" style="max-width:100%;"></iframe>',
+                        'content': '<iframe src="//www.youtube.com/embed/'+id+'" width="'+width+'" height="'+height+'" style="max-width:100%;"'+(modal.lightbox.options.allowfullscreen?' allowfullscreen':'')+'></iframe>',
                         'width': width,
                         'height': height
                     };
@@ -400,7 +401,7 @@
                 var id, resolve = function(id, width, height) {
 
                     data.meta = {
-                        'content': '<iframe src="//player.vimeo.com/video/'+id+'" width="'+width+'" height="'+height+'" style="width:100%;box-sizing:border-box;"></iframe>',
+                        'content': '<iframe src="//player.vimeo.com/video/'+id+'" width="'+width+'" height="'+height+'" style="width:100%;box-sizing:border-box;"'+(modal.lightbox.options.allowfullscreen?' allowfullscreen':'')+'></iframe>',
                         'width': width,
                         'height': height
                     };
@@ -492,7 +493,7 @@
                 var resolve = function (source, width, height) {
 
                     data.meta = {
-                        'content': '<iframe class="uk-responsive-width" src="' + source + '" width="' + width + '" height="' + height + '"></iframe>',
+                        'content': '<iframe class="uk-responsive-width" src="' + source + '" width="' + width + '" height="' + height + '"'+(modal.lightbox.options.allowfullscreen?' allowfullscreen':'')+'></iframe>',
                         'width': width,
                         'height': height
                     };


### PR DESCRIPTION
If the option is set to true, the `allowfullscreen` attribute will be added to Iframes in the Lightbox, allowing videos to toggle fullscreen.

This is required for Youtube and Vimeo. Seems like Vimeo recently changed their players behavior because toggling fullscreen was working without this attribute a few month ago. On the current UIkit (Version 2.26.3) docs you can observe, that toggling fullscreen does not work for Vimeo or Youtube.

Tested
- IE 11 (W10)
- Edge (W10)
- Firefox (W10)
- Chrome (W10)