### PR TITLE
add check for inited modal js before resizing

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -6,7 +6,10 @@
 
     UI.$win.on("resize orientationchange", UI.Utils.debounce(function(){
         UI.$('.uk-modal.uk-open').each(function(){
-            UI.$(this).data('modal').resize();
+            var modal = UI.$(this).data("modal");
+            if (modal) {
+                modal.resize();
+            }
         });
     }, 150));
 


### PR DESCRIPTION
There could be custom Modal scripts using the classess but not the JS, in which case the resize functions would trigger an silly error. The solution is simple, I hope it's accepted.