### PR TITLE
Fix: Switching dosn't work when using <a> without href attribute on responsive list

### DIFF
--- a/src/js/core/tab.js
+++ b/src/js/core/tab.js
@@ -149,7 +149,8 @@
 
                         if (!item.hasClass('uk-disabled')) {
 
-                            clone = item[0].outerHTML.replace('<a ', '<a data-index="'+i+'" ');
+                            clone = UI.$(item[0].outerHTML);
+                            clone.find('a').data('index', i);
 
                             this.responsivetab.lst.append(clone);
                         }


### PR DESCRIPTION
I created a list like this one bellow
`<ul class="uk-tab" data-uk-tab>`
`<li><a>...</a></li>`
`<li><a>...</a></li>`
`</ul>`
But when I click on List on Responsive dropdown, It doesn't switch, I
found out that dosn't happen because <a> in responsive list don't have
data-index attribue.