### PR TITLE
change from 600px to 300px min-height

### DIFF
--- a/src/less/core/utility.less
+++ b/src/less/core/utility.less
@@ -39,7 +39,7 @@
 @utility-align-horizontal:                      15px;
 @utility-align-vertical:                        15px;
 
-@utility-height-viewport-min-height:            600px;
+@utility-height-viewport-min-height:            300px;
 
 @utility-margin:                                15px;
 @utility-margin-small:                          5px;


### PR DESCRIPTION
min-height should be 300px to support landscape mode on mobile devices.

Fixes #1993
