### PR TITLE
feat(dropdown): add uk-dropdown-autoflip modifier

### DIFF
--- a/src/js/core/dropdown.js
+++ b/src/js/core/dropdown.js
@@ -300,7 +300,7 @@
             if (!this.dropdown.length) return;
 
             // reset
-            this.dropdown.removeClass('uk-dropdown-top uk-dropdown-bottom uk-dropdown-left uk-dropdown-right uk-dropdown-stack').css({
+            this.dropdown.removeClass('uk-dropdown-top uk-dropdown-bottom uk-dropdown-left uk-dropdown-right uk-dropdown-stack uk-dropdown-autoflip').css({
                 topLeft :'',
                 left :'',
                 marginLeft :'',
@@ -367,6 +367,7 @@
 
                         pp  = fdpos.split('-');
                         css = variants[fdpos] ? variants[fdpos] : variants['bottom-left'];
+                        dropdown.addClass('uk-dropdown-autoflip');
 
                         // check flipped
                         if (this.checkBoundary(pos.left + css.left, pos.top + css.top, width, height, boundarywidth)) {


### PR DESCRIPTION
Add functionality to automatically apply a uk-dropdown-autoflip class to the dropdown element, when the boundary check results in a flipping of the dropdown (e.g. not enough space on the right, so flip it to the left and add uk-dropdown-autoflip).