### PR TITLE
Fixed links in slideshow and slider for Joomla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### WIP
 
+  - Fixed links in slideshow and slider for Joomla
   - Fixed slideshow bug when using slideshow-fx based effects
   - Fixed dropdown error if now offset element exists
   - Fixed dropdowns on windows with touch support

--- a/src/js/components/slider.js
+++ b/src/js/components/slider.js
@@ -159,7 +159,7 @@
             }
 
             UI.domObserve(this.element, function(e) {
-                if ($this.element.children(':not([data-slide])').length) {
+                if ($this.element.children(':not([data-slider-slide])').length) {
                     $this.update(true);
                 }
             });
@@ -177,7 +177,7 @@
 
             this.items.each(function(idx){
 
-                item      = UI.$(this).attr('data-slide', idx);
+                item      = UI.$(this).attr('data-slider-slide', idx);
                 size      = item.css({'left': '', 'width':''})[0].getBoundingClientRect();
                 width     = size.width;
                 cwidth    = item.width();

--- a/src/js/components/slideshow.js
+++ b/src/js/components/slideshow.js
@@ -156,7 +156,7 @@
             });
 
             UI.domObserve(this.element, function(e) {
-                if ($this.container.children(':not([data-slide])').not('.uk-slideshow-ghost').length) {
+                if ($this.container.children(':not([data-slideshow-slide])').not('.uk-slideshow-ghost').length) {
                     $this.update(true);
                 }
             });
@@ -278,7 +278,7 @@
                 }
 
                 slide.data('processed', ++processed);
-                slide.attr('data-slide', type);
+                slide.attr('data-slideshow-slide', type);
             });
 
             if (processed) {


### PR DESCRIPTION
Fixed the not opening links in Joomla for Slider and Slideshow by renaming data-slide into data-slider-slide / data-slideshow-slide.