### PR TITLE
Break words inside of tooltips (issue #2051)

### DIFF
--- a/src/less/components/tooltip.less
+++ b/src/less/components/tooltip.less
@@ -58,6 +58,7 @@
     color: @tooltip-color;
     font-size: @tooltip-font-size;
     line-height: @tooltip-line-height;
+    word-break: break-all;
     .hook-tooltip;
 }
 

--- a/tests/components/tooltip.html
+++ b/tests/components/tooltip.html
@@ -24,6 +24,12 @@
             <div class="tooltip-container">
                 <div class="uk-tooltip uk-tooltip-top" style="display: block;">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
             </div>
+            
+            <div class="tooltip-container">
+                <div class="uk-tooltip uk-tooltip-top" style="display: block;">
+                Pneumonoultramicroscopicsilicovolcanoconiosis should fit on a tooltip.
+                </div>
+            </div>
 
             <p>
                 <button class="uk-button" data-uk-tooltip title="Hello World">No options</button>


### PR DESCRIPTION
Break words inside of tooltips when they overflow it's space (Fixes issue #2051)