### PR TITLE
Uses today as the default date even when the 'minDate' option is set (issue #2024)

### DIFF
--- a/src/js/components/datepicker.js
+++ b/src/js/components/datepicker.js
@@ -160,7 +160,7 @@
             this.current  = this.element.val() ? moment(this.element.val(), this.options.format) : moment();
 
             this.on('click focus', function(){
-                if (active!==$this) $this.pick(this.value ? this.value:($this.options.minDate ? $this.options.minDate :''));
+                if (active!==$this) $this.pick(this.value ? this.value:'');
             }).on('change', function(){
 
                 if ($this.element.val() && !moment($this.element.val(), $this.options.format).isValid()) {

--- a/tests/components/datepicker.html
+++ b/tests/components/datepicker.html
@@ -75,6 +75,22 @@
                     </div>
                 </div>
 
+                <div class="uk-form-row">
+                    <label class="uk-form-label" for="form-date">Date</label>
+                    <div class="uk-form-controls">
+                        <input type="text" data-uk-datepicker="{format:'DD.MM.YYYY', minDate:-7, maxDate:7}">
+                        <p class="uk-form-help-block">Only allowed current date +- 7 days, default date should be today</p>
+                    </div>
+                </div>
+
+                <div class="uk-form-row">
+                    <label class="uk-form-label" for="form-date">Date</label>
+                    <div class="uk-form-controls">
+                        <input type="text" data-uk-datepicker="{format:'DD.MM.YYYY', minDate:'01.10.2016'}">
+                        <p class="uk-form-help-block"><code>minDate:'01.10.2016'</code>, default date should be today</p>
+                    </div>
+                </div>
+
             </form>
 
         </div>


### PR DESCRIPTION
As stated in the issue #2024, when the `minDate` option is set with a string, the default date for the datepicker is the min date. This PR remove this functionality, making it behave in the same way that when the `minDate` option is set with an integer.