### PR TITLE
Remove dotted line shown by default in Firefox on focused dropdowns (issue #2038)

### DIFF
--- a/src/less/core/dropdown.less
+++ b/src/less/core/dropdown.less
@@ -95,6 +95,9 @@
     .hook-dropdown;
 }
 
+/* Focus */
+.uk-dropdown:focus { outline: none; }
+
 /*
  * 1. Show dropdown
  * 2. Set animation


### PR DESCRIPTION
Remove dotted line shown by default in Firefox on focused dropdowns (issue #2038).
