### PR TITLE
Reset button group whitespace hack for uk-dropdown-blank (issue #2057)

### DIFF
--- a/src/less/core/dropdown.less
+++ b/src/less/core/dropdown.less
@@ -65,6 +65,7 @@
  * 2. Set position
  * 3. Box-sizing is needed for `uk-dropdown-justify`
  * 4. Set width
+ * 5. Reset button group whitespace hack
  */
 
 .uk-dropdown,
@@ -78,6 +79,9 @@
     box-sizing: border-box;
     /* 4 */
     width: @dropdown-width;
+    /* 5 */
+    font-size: @dropdown-font-size;
+    white-space: normal;
 }
 
 /*
@@ -90,7 +94,6 @@
     background: @dropdown-background;
     color: @dropdown-color;
     /* 1 */
-    font-size: @dropdown-font-size;
     vertical-align: top;
     .hook-dropdown;
 }

--- a/tests/core/button.html
+++ b/tests/core/button.html
@@ -249,6 +249,25 @@
                 </div>
             </div>
 
+            <div class="uk-margin" data-uk-margin>
+                <div class="uk-button-group">
+                    <div class="uk-position-relative uk-display-inline-block" data-uk-dropdown="{mode:'click'}">
+                        <a href="#" class="uk-button">Dropdown</a>
+                        <div class="uk-dropdown-blank uk-panel uk-panel-box uk-panel-box-hover">
+                            <h3 class="uk-panel-title">Title 1</h3>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+                        </div>
+                    </div>
+                    <div class="uk-position-relative uk-display-inline-block" data-uk-dropdown="{mode:'click'}">
+                        <a href="#" class="uk-button">Dropdown</a>
+                        <div class="uk-dropdown-blank uk-panel uk-panel-box uk-panel-box-hover">
+                            <h3 class="uk-panel-title">Title 2</h3>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <h2>Javascript</h2>
 
             <p>


### PR DESCRIPTION
To fix issue #2057, I have added the declaration `white-space: normal` and moved `font-size: @dropdown-font-size` from the `.uk-dropdown` rule-set to the one that also includes the selector `.uk-dropdown-blank`. I also added a test to reproduce the problem:
- Before:
  ![image](https://cloud.githubusercontent.com/assets/895865/19162122/e7227c28-8bf6-11e6-8aa8-37fc4b49e6a7.png)
- After:
  ![image](https://cloud.githubusercontent.com/assets/895865/19162134/f512e19c-8bf6-11e6-8689-04bda1f2b23e.png)
