### PR TITLE
add Chips for tags and contacts

### DIFF
--- a/src/less/core/chips.less
+++ b/src/less/core/chips.less
@@ -1,0 +1,68 @@
+// Name:            Chips
+// Description:     Defines styles for Chips
+//
+// Component:       `uk-chip`
+//
+// Modifiers:       `uk-chip-close`
+//                  `uk-chip-img`
+//                  `uk-chips`
+//                  `uk-chips-focus`
+//                  `uk-chips-hover`
+//                  `uk-chips uk-chip.selected`
+//                  `uk-chips .input`
+//
+// ========================================================================
+
+
+// Variables
+// ========================================================================
+@chip-bg-color:         #e4e4e4 !default;
+@chip-border-color:     #9e9e9e !default;
+@chip-selected-color:   #26a69a !default;
+@chip-margin:           5px !default;
+@chip-input-font-size:  1rem !default;
+@chip-input-margin:     0 0 20px 0 !default;
+@chip-input-height:     3rem !default;
+/* ========================================================================
+   Component: Chips
+ ========================================================================== */
+
+.uk-chip {
+  display: inline-block;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(0,0,0,.6);
+  line-height: 32px;
+  padding: 0 12px;
+  border-radius: 16px;
+  background-color: @chip-bg-color;
+  margin-bottom: @chip-margin;
+  margin-right: @chip-margin;
+}
+
+.uk-chip img{
+  float: left;
+  margin: 0 8px 0 -12px;
+  height: 32px;
+  width: 32px;
+  border-radius: 50%
+}
+
+.uk-chip .close{
+  cursor: pointer;
+  float: right;
+  font-size: 16px;
+  line-height: 16px;
+  padding-left: 8px;
+}
+
+.uk-chips{
+  border: none;
+  border-bottom: 1px solid @chip-border-color;
+  box-shadow: none;
+  margin: @chip-input-margin;
+  min-height: 45px;
+  outline: none;
+  transition: all .3s;
+}

--- a/src/less/uikit.less
+++ b/src/less/uikit.less
@@ -12,6 +12,9 @@
 @import "core/comment.less";
 @import "core/cover.less";
 
+// Chips
+@import "core/chips.less";
+
 // Navs
 @import "core/nav.less";
 @import "core/navbar.less";


### PR DESCRIPTION
add Chips that can be used to represent small blocks of information, can be used for show contacts or tags
