### PR TITLE
lightbox fix - display images which has query strings in the url

### DIFF
--- a/src/js/components/lightbox.js
+++ b/src/js/components/lightbox.js
@@ -277,7 +277,7 @@
 
             lightbox.on('showitem.uk.lightbox', function(e, data){
 
-                if (data.type == 'image' || data.source && data.source.match(/\.(jpg|jpeg|png|gif|svg)$/i)) {
+                if (data.type == 'image' || data.source && data.source.match(/\.(jpg|jpeg|png|gif|svg)($|\?)/i)) {
 
                     var resolve = function(source, width, height) {
 


### PR DESCRIPTION
When images have timestamps on them the Lightbox will not open them ...

`<a href="/images/gallery/image-1.jpg?57ed752b" data-uk-lightbox="{group:'gallery'}" title="Title">
       <img src="/images/gallery/image-1-thumb.jpg?57ed77ee" alt="Title">
</a>
`

Fixed it. 
