### PR TITLE
Updating bower.json to include jQuery 3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
       "./dist/fonts/FontAwesome.otf"
   ],
   "dependencies": {
-    "jquery": "~2.1.0"
+    "jquery": "~2.1.0 || ~3.0.0"
   },
   "ignore": [
     "node_modules",


### PR DESCRIPTION
Updating bower.json to include the compatible jQuery ~3.0.0 to address issue #2016
