### PR TITLE
Fix Offcanvas documentation

### DIFF
--- a/docs/offcanvas.html
+++ b/docs/offcanvas.html
@@ -366,7 +366,7 @@
 UIkit.offcanvas.show('#my-id');
 
 // Hide any active offcanvas. Set force to true, if you don't want any animation.
-UIkit.offcanvas.hide([force = false])
+UIkit.offcanvas.hide(false)
 </code></pre>
 
                         <hr class="uk-article-divider">


### PR DESCRIPTION
When adding a custom element which when clicked, hides the active offcanvas menu, the function parameter needs to be defined as a simple boolean, not within an array:

**Incorrect:** `UIkit.offcanvas.hide([force = false]);`

**Correct:** `UIkit.offcanvas.hide(false);`

If you use the first approach, it does hide the offcanvas, however the animation will never work.