### PR TITLE
add jqeury as an external dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "main": "dist/js/uikit.js",
   "dependencies": {
+    "jquery": "^3.1.1",
     "node-promise": "^0.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
First, I love uikit! Thank you ❤️ 

Second, UIKit code seems to [depend on jquery][1]:

```js
    if (!window.jQuery) {
        throw new Error('UIkit 2.x requires jQuery');
    }
```

but jquery isn't a listed dependency in [`package.json`][2]. So, I've added it assuming it's required 😃 

[1]: https://github.com/uikit/uikit/blob/5d0ce9baace9b824fdc65b09da0f1a17cddce2b3/src/js/core/core.js#L31-L33
[2]: https://github.com/uikit/uikit/blob/895172df745bb276404a0644267a2a297124d56e/package.json#L26-L28
