### PR TITLE
Sticky: dont set active when initial offset is 0

### DIFF
--- a/src/js/core/sticky.js
+++ b/src/js/core/sticky.js
@@ -139,7 +139,7 @@ export default function (UIkit) {
                         return;
                     }
 
-                    if (this.inactive || scroll < this.top || this.showOnUp && (dir !== 'up' || dir === 'up' && !isActive && scroll <= this.bottomOffset)) {
+                    if (this.inactive || scroll <= this.top || this.showOnUp && (dir !== 'up' || dir === 'up' && !isActive && scroll <= this.bottomOffset)) {
 
                         if (!isActive) {
                             return;


### PR DESCRIPTION
When using sticky on element that has an initial offset of 0 (when it's the first element of the body with no margin before) then this element always have the active class (at page loading and also when scroll = 0)

In my case it was annoying because I use the ``active class`` to detect when the element was sticked at the top in order to apply it a custom style.

This PR makes those elements being active only when scroll is more than 0.

Unfortunately I couldn't add unit test because the test templates prepend elements at the beginning of the body.