### PR TITLE
Fix switcher.show() when used in onReady event

### DIFF
--- a/src/js/core/switcher.js
+++ b/src/js/core/switcher.js
@@ -64,6 +64,11 @@ export default function (UIkit) {
         methods: {
 
             show(item) {
+                
+                if(!this.toggles) {
+                    this.active = item;
+                    return;
+                }
 
                 var length = this.toggles.length,
                     prev = this.connects.children(`.${this.cls}`).index(),


### PR DESCRIPTION
I'm trying to do following:

```javascript
$(function() {
    UIkit.tab("#tabs")[0].show(2);
});
```

This doesn't work when the page is opened in background via middle mouse button, because FastDOM requestAnimationFrame callback is not called and Tab/switchers's `update` method is not called until after user switches to the tab, and `show` depends on data initialized in `update`.

Maybe I'm doing it wrong? Is there a way to wait until the first frame is painted and all components are initialized?