### PR TITLE
fix offcanvas flip margin

### DIFF
--- a/src/less/components/offcanvas.less
+++ b/src/less/components/offcanvas.less
@@ -86,7 +86,7 @@
 .uk-offcanvas-page-animation { margin-left: @offcanvas-bar-width; }
 
 /* Flip modifier */
-.uk-offcanvas-flip.uk-offcanvas-page-animation { margin-left: -@offcanvas-bar-width; }
+.uk-offcanvas-flip.uk-offcanvas-page-animation { margin-left: -@offcanvas-bar-width * 2; }
 
 /*
  * Prevent scrollbar on page if overlay is used


### PR DESCRIPTION
Don't ask me why, but the flip margin must be double size. Probably it has to do with the fact it is applying left negative margin instead of the right positive. Anyhow, accept the change or check what is going on there :) Thanks! 