### PR TITLE
Default the offcanvas to dark.

### DIFF
--- a/src/less/components/offcanvas.less
+++ b/src/less/components/offcanvas.less
@@ -29,7 +29,7 @@
 @offcanvas-bar-padding-vertical:                @global-margin;
 @offcanvas-bar-padding-horizontal:              @global-margin;
 @offcanvas-bar-background:                      @global-secondary-background;
-@offcanvas-bar-color-mode:                      light;
+@offcanvas-bar-color-mode:                      dark;
 
 
 /* ========================================================================


### PR DESCRIPTION
Defaulting to light is too presumptive. Also, the demo on the documentation is dark so the default setting should match.