### PR TITLE
adds moduleId for umd build

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -33,7 +33,8 @@ function compile(file, dest, external, globals) {
             globals,
             format: 'umd',
             banner: util.banner,
-            moduleName: 'UIkit'
+            moduleName: 'UIkit',
+            moduleId: 'uikit'
         }).code))
         .then(() => util.write(`${dest}.min.js`, `${util.banner}\n${uglify.minify(`${dest}.js`).code}`))
         .catch(console.log);


### PR DESCRIPTION
to avoid the (mismatched anonymous define module) error on frameworks like aurelia, details [here](http://requirejs.org/docs/errors.html#mismatch).
fixes #2376