### PR TITLE
Fixes Edge/IE11 Rounding issues

### DIFF
--- a/src/less/components/width.less
+++ b/src/less/components/width.less
@@ -32,10 +32,10 @@
 }
 
 .uk-child-width-1-2 > * { width: 50%; }
-.uk-child-width-1-3 > * { width: ~'calc(100% * 1 / 3)'; }
+.uk-child-width-1-3 > * { width: ~'calc(100% * 1 / 3.01)'; }
 .uk-child-width-1-4 > * { width: 25%; }
 .uk-child-width-1-5 > * { width: 20%; }
-.uk-child-width-1-6 > * { width: ~'calc(100% * 1 / 6)'; }
+.uk-child-width-1-6 > * { width: ~'calc(100% * 1 / 6.01)'; }
 
 .uk-child-width-auto > * { width: auto; }
 
@@ -70,10 +70,10 @@
 
     .uk-child-width-1-1\@s > * { width: 100%; }
     .uk-child-width-1-2\@s > * { width: 50%; }
-    .uk-child-width-1-3\@s > * { width: ~'calc(100% * 1 / 3)'; }
+    .uk-child-width-1-3\@s > * { width: ~'calc(100% * 1 / 3.01)'; }
     .uk-child-width-1-4\@s > * { width: 25%; }
     .uk-child-width-1-5\@s > * { width: 20%; }
-    .uk-child-width-1-6\@s > * { width: ~'calc(100% * 1 / 6)'; }
+    .uk-child-width-1-6\@s > * { width: ~'calc(100% * 1 / 6.01)'; }
 
     .uk-child-width-auto\@s > * { width: auto; }
     .uk-child-width-expand\@s > * { width: 1px; }
@@ -93,10 +93,10 @@
 
     .uk-child-width-1-1\@m > * { width: 100%; }
     .uk-child-width-1-2\@m > * { width: 50%; }
-    .uk-child-width-1-3\@m > * { width: ~'calc(100% * 1 / 3)'; }
+    .uk-child-width-1-3\@m > * { width: ~'calc(100% * 1 / 3.01)'; }
     .uk-child-width-1-4\@m > * { width: 25%; }
     .uk-child-width-1-5\@m > * { width: 20%; }
-    .uk-child-width-1-6\@m > * { width: ~'calc(100% * 1 / 6)'; }
+    .uk-child-width-1-6\@m > * { width: ~'calc(100% * 1 / 6.01)'; }
 
     .uk-child-width-auto\@m > * { width: auto; }
     .uk-child-width-expand\@m > * { width: 1px; }
@@ -116,10 +116,10 @@
 
     .uk-child-width-1-1\@l > * { width: 100%; }
     .uk-child-width-1-2\@l > * { width: 50%; }
-    .uk-child-width-1-3\@l > * { width: ~'calc(100% * 1 / 3)'; }
+    .uk-child-width-1-3\@l > * { width: ~'calc(100% * 1 / 3.01)'; }
     .uk-child-width-1-4\@l > * { width: 25%; }
     .uk-child-width-1-5\@l > * { width: 20%; }
-    .uk-child-width-1-6\@l > * { width: ~'calc(100% * 1 / 6)'; }
+    .uk-child-width-1-6\@l > * { width: ~'calc(100% * 1 / 6.01)'; }
 
     .uk-child-width-auto\@l > * { width: auto; }
     .uk-child-width-expand\@l > * { width: 1px; }
@@ -139,10 +139,10 @@
 
     .uk-child-width-1-1\@xl > * { width: 100%; }
     .uk-child-width-1-2\@xl > * { width: 50%; }
-    .uk-child-width-1-3\@xl > * { width: ~'calc(100% * 1 / 3)'; }
+    .uk-child-width-1-3\@xl > * { width: ~'calc(100% * 1 / 3.01)'; }
     .uk-child-width-1-4\@xl > * { width: 25%; }
     .uk-child-width-1-5\@xl > * { width: 20%; }
-    .uk-child-width-1-6\@xl > * { width: ~'calc(100% * 1 / 6)'; }
+    .uk-child-width-1-6\@xl > * { width: ~'calc(100% * 1 / 6.01)'; }
 
     .uk-child-width-auto\@xl > * { width: auto; }
     .uk-child-width-expand\@xl > * { width: 1px; }
@@ -176,8 +176,8 @@
 .uk-width-1-2 { width: 50%; }
 
 /* Thirds */
-.uk-width-1-3 { width: ~'calc(100% * 1 / 3)'; }
-.uk-width-2-3 { width: ~'calc(100% * 2 / 3)'; }
+.uk-width-1-3 { width: ~'calc(100% * 1 / 3.01)'; }
+.uk-width-2-3 { width: ~'calc(100% * 2 / 3.01)'; }
 
 /* Quarters */
 .uk-width-1-4 { width: 25%; }
@@ -190,8 +190,8 @@
 .uk-width-4-5 { width: 80%; }
 
 /* Sixths */
-.uk-width-1-6 { width: ~'calc(100% * 1 / 6)'; }
-.uk-width-5-6 { width: ~'calc(100% * 5 / 6)'; }
+.uk-width-1-6 { width: ~'calc(100% * 1 / 6.01)'; }
+.uk-width-5-6 { width: ~'calc(100% * 5 / 6.01)'; }
 
 /* Pixel */
 .uk-width-small { width: @width-small-width; }
@@ -223,8 +223,8 @@
     .uk-width-1-2\@s { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@s { width: ~'calc(100% * 1 / 3)'; }
-    .uk-width-2-3\@s { width: ~'calc(100% * 2 / 3)'; }
+    .uk-width-1-3\@s { width: ~'calc(100% * 1 / 3.01)'; }
+    .uk-width-2-3\@s { width: ~'calc(100% * 2 / 3.01)'; }
 
     /* Quarters */
     .uk-width-1-4\@s { width: 25%; }
@@ -237,8 +237,8 @@
     .uk-width-4-5\@s { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@s { width: ~'calc(100% * 1 / 6)'; }
-    .uk-width-5-6\@s { width: ~'calc(100% * 5 / 6)'; }
+    .uk-width-1-6\@s { width: ~'calc(100% * 1 / 6.01)'; }
+    .uk-width-5-6\@s { width: ~'calc(100% * 5 / 6.01)'; }
 
     /* Pixel */
     .uk-width-small\@s { width: @width-small-width; }
@@ -272,8 +272,8 @@
     .uk-width-1-2\@m { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@m { width: ~'calc(100% * 1 / 3)'; }
-    .uk-width-2-3\@m { width: ~'calc(100% * 2 / 3)'; }
+    .uk-width-1-3\@m { width: ~'calc(100% * 1 / 3.01)'; }
+    .uk-width-2-3\@m { width: ~'calc(100% * 2 / 3.01)'; }
 
     /* Quarters */
     .uk-width-1-4\@m { width: 25%; }
@@ -286,8 +286,8 @@
     .uk-width-4-5\@m { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@m { width: ~'calc(100% * 1 / 6)'; }
-    .uk-width-5-6\@m { width: ~'calc(100% * 5 / 6)'; }
+    .uk-width-1-6\@m { width: ~'calc(100% * 1 / 6.01)'; }
+    .uk-width-5-6\@m { width: ~'calc(100% * 5 / 6.01)'; }
 
     /* Pixel */
     .uk-width-small\@m { width: @width-small-width; }
@@ -321,8 +321,8 @@
     .uk-width-1-2\@l { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@l { width: ~'calc(100% * 1 / 3)'; }
-    .uk-width-2-3\@l { width: ~'calc(100% * 2 / 3)'; }
+    .uk-width-1-3\@l { width: ~'calc(100% * 1 / 3.01)'; }
+    .uk-width-2-3\@l { width: ~'calc(100% * 2 / 3.01)'; }
 
     /* Quarters */
     .uk-width-1-4\@l { width: 25%; }
@@ -335,8 +335,8 @@
     .uk-width-4-5\@l { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@l { width: ~'calc(100% * 1 / 6)'; }
-    .uk-width-5-6\@l { width: ~'calc(100% * 5 / 6)'; }
+    .uk-width-1-6\@l { width: ~'calc(100% * 1 / 6.01)'; }
+    .uk-width-5-6\@l { width: ~'calc(100% * 5 / 6.01)'; }
 
     /* Pixel */
     .uk-width-small\@l { width: @width-small-width; }
@@ -370,8 +370,8 @@
     .uk-width-1-2\@xl { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@xl { width: ~'calc(100% * 1 / 3)'; }
-    .uk-width-2-3\@xl { width: ~'calc(100% * 2 / 3)'; }
+    .uk-width-1-3\@xl { width: ~'calc(100% * 1 / 3.01)'; }
+    .uk-width-2-3\@xl { width: ~'calc(100% * 2 / 3.01)'; }
 
     /* Quarters */
     .uk-width-1-4\@xl { width: 25%; }
@@ -384,8 +384,8 @@
     .uk-width-4-5\@xl { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@xl { width: ~'calc(100% * 1 / 6)'; }
-    .uk-width-5-6\@xl { width: ~'calc(100% * 5 / 6)'; }
+    .uk-width-1-6\@xl { width: ~'calc(100% * 1 / 6.01)'; }
+    .uk-width-5-6\@xl { width: ~'calc(100% * 5 / 6.01)'; }
 
     /* Pixel */
     .uk-width-small\@xl { width: @width-small-width; }


### PR DESCRIPTION
On certain viewport sizes e.g 1280px wide IE10/IE11/Edge13/Edge14 Would round the numbers too high, causing 3 and 6 column grids, fold onto new lines.

By adding the extra decimal places in it prevents the rounding pushing items onto new lines.

Effectively turns this

<img width="1085" alt="dashboard" src="https://cloud.githubusercontent.com/assets/1094740/22853266/b358483e-f049-11e6-9de8-19d1f2ec3193.png">

into

<img width="1112" alt="dashboard" src="https://cloud.githubusercontent.com/assets/1094740/22853270/ce99c794-f049-11e6-9930-d91da127ea66.png">

