### PR TITLE
Fix height-match not working on initial page load

### DIFF
--- a/src/js/core/height-match.js
+++ b/src/js/core/height-match.js
@@ -59,7 +59,7 @@ export default function (UIkit) {
 
             },
 
-            events: ['resize']
+            events: ['load', 'resize']
 
         },
 


### PR DESCRIPTION
The uk-height-match attribute does not work on the initial page load, only when the browser window is resized.