### PR TITLE
Fix issue with uk-grid-match flex property overriding uk-flex-none

### DIFF
--- a/src/less/components/grid.less
+++ b/src/less/components/grid.less
@@ -335,7 +335,9 @@
 }
 
 .uk-grid-match > * > :not([class*='uk-width']),
-.uk-grid-item-match > :not([class*='uk-width']) {
+.uk-grid-item-match > :not([class*='uk-width']),
+.uk-grid-match > * > :not([class*='uk-flex-none']),
+.uk-grid-item-match > :not([class*='uk-flex-none']) {
     /* 2 */
     box-sizing: border-box;
     width: 100%;

--- a/src/scss/components/grid.scss
+++ b/src/scss/components/grid.scss
@@ -335,7 +335,9 @@ $grid-divider-border:                            $global-border !default;
 }
 
 .uk-grid-match > * > :not([class*='uk-width']),
-.uk-grid-item-match > :not([class*='uk-width']) {
+.uk-grid-item-match > :not([class*='uk-width']),
+.uk-grid-match > * > :not([class*='uk-flex-none']),
+.uk-grid-item-match > :not([class*='uk-flex-none']) {
     /* 2 */
     box-sizing: border-box;
     width: 100%;


### PR DESCRIPTION
**Issue:**

`.uk-grid-match` was overriding `.uk-flex-none`'s `flex: none` property. 

I think the developer should have the option to get one element to have  `.uk-flex-none` working correctly inside a `.uk-grid-match` element without fixing it every time the necessity arises. 

Note:
btw, when I ran `npm run compile`, a lot of more stuff changed than my actual work, hence this PR only having .less and .scss changes.