### PR TITLE
Smooth scrolling with slashes in hash

### DIFF
--- a/src/js/core/scroll.js
+++ b/src/js/core/scroll.js
@@ -49,7 +49,8 @@ export default function (UIkit) {
                 }
 
                 e.preventDefault();
-                this.scrollToElement($(this.$el[0].hash).length ? this.$el[0].hash : 'body');
+                var elHash = this.$el[0].hash.replace('/', '\\/');
+                this.scrollToElement($(elHash).length ? elHash : 'body');
             }
 
         }

--- a/src/js/core/scroll.js
+++ b/src/js/core/scroll.js
@@ -49,7 +49,7 @@ export default function (UIkit) {
                 }
 
                 e.preventDefault();
-                var elHash = this.$el[0].hash.replace('/', '\\/');
+                var elHash = this.$el[0].hash.replace(/\//g, '\\/');
                 this.scrollToElement($(elHash).length ? elHash : 'body');
             }
 


### PR DESCRIPTION
This PR escapes slashes in the hash of a link, e.g. ``<a href="#anchor/sub">link</a>``, to enable smooth scrolling for these links. Let me know if you have any comments or concerns.