### PR TITLE
Let tooltip wrap long text

### DIFF
--- a/src/less/components/tooltip.less
+++ b/src/less/components/tooltip.less
@@ -58,6 +58,7 @@
     border-radius: @tooltip-border-radius;
     color: @tooltip-color;
     font-size: @tooltip-font-size;
+    word-wrap: break-word;
     .hook-tooltip;
 }
 

--- a/src/scss/components/tooltip.scss
+++ b/src/scss/components/tooltip.scss
@@ -58,6 +58,7 @@ $tooltip-margin:                                 10px !default;
     border-radius: $tooltip-border-radius;
     color: $tooltip-color;
     font-size: $tooltip-font-size;
+    word-wrap: break-word;
     @if(mixin-exists(hook-tooltip)) {@include hook-tooltip();}
 }
 


### PR DESCRIPTION
Let tooltip wrap long text using `word-wrap: break-word`

https://codepen.io/zzseba78/pen/XejEvR