### PR TITLE
Fix stacked modal removing info from DOM required by previous modal

### DIFF
--- a/src/js/mixin/modal.js
+++ b/src/js/mixin/modal.js
@@ -110,9 +110,13 @@ export default {
 
             handler() {
                 if (this.component.active === this) {
-                    docElement.removeClass(this.clsPage);
-                    this.body.css('overflow-y', '');
-                    this.component.active = null;
+                    if (this.stack) {
+                        this.component.active = this.prev;
+                    } else {
+                        docElement.removeClass(this.clsPage);
+                        this.body.css('overflow-y', '');
+                        this.component.active = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixed an issue where closing a stacked modal would remove the `uk-modal-page`
class from the html tag and `overflow-y` style from the body tag, despite that
information still needing to be present for the modal which the stacked modal
was opened from. This would manifest itself as being able to scroll the page
behind a modal if you just closed a stacked modal.

Also, on the hidden event of a stacked modal, I set the active component to the
previous modal, rather than setting it to `null` as done previously.

To reproduce the issue this PR fixes:

- Jump to https://getuikit.com/assets/uikit/tests/modal.html
- Under the **Stack** heading, click `Modal 1`
- After modal pops up, attempt to scroll page, see that page does not scroll
- Click the `Next` button in the modal that pops up
- Click the `Cancel` button or `x` to close the stacked modal that pops up and
  return to previous modal
- Attempt to scroll page, see that page *does* scroll

The issue is that page does not scroll when modal is opened, but does scroll
when stacked modal is closed.

This PR causes the page to not scroll in both cases.

**TLDR**: Closing a stacked modal clears `uk-modal-page` class required by previous modal.