### PR TITLE
Take the stack option into account in offcanvas - fixes #2913

### DIFF
--- a/src/js/core/offcanvas.js
+++ b/src/js/core/offcanvas.js
@@ -162,7 +162,7 @@ export default function (UIkit) {
                 handler() {
                     removeClass(this.content, this.clsContentAnimation);
 
-                    if (this.mode === 'none' || this.getActive() && this.getActive() !== this) {
+                    if (this.mode === 'none' || (!this.stack && this.getActive() && this.getActive() !== this)) {
                         trigger(this.panel, transitionend);
                     }
                 }


### PR DESCRIPTION
See https://github.com/uikit/uikit/issues/2913

Currently unresolved, but should be easy to fix: clicking a button will trigger the `transitionend` event prematurely, because it seems to bubble up to the offcanvas panel. To see this in effect, compare the smoothness of the transition when clicking compared to using the `esc` key.

Comparing `e.currentTarget` to `transitionElement` will likely resolve this issue in Modal (mixin) `_toggleImmediate`.