### PR TITLE
Use the same name as in components _import.less

### DIFF
--- a/src/less/theme/_import.less
+++ b/src/less/theme/_import.less
@@ -63,7 +63,7 @@
 @import "sortable.less";
 @import "countdown.less";
 
-// Utility
+// Utilities
 @import "animation.less";
 @import "width.less";
 @import "text.less";


### PR DESCRIPTION
 in components _import.less we have:
`// Utilities`

 in theme _import.less we have:
`// Utility`

this PR remove the difference