### PR TITLE
Prevent console error, if target doesn't exist

### DIFF
--- a/src/js/util/event.js
+++ b/src/js/util/event.js
@@ -16,7 +16,7 @@ export function on(...args) {
         listener = detail(listener);
     }
 
-    type.split(' ').forEach(type => target.addEventListener(type, listener, useCapture));
+    type.split(' ').forEach(type => target ? target.addEventListener(type, listener, useCapture) : null);
     return () => off(target, type, listener, useCapture);
 }
 


### PR DESCRIPTION
If you add a event listener via `UIkit.util.on(...);` and your selector doesn't resolve to an existing element, the function will throw following error:

```javascript
Uncaught TypeError: Cannot read property 'addEventListener' of null
```

It cannot attach an event listener on `null`.

Right now as a workaround I have to do something like this:
```javascript
const element = document.getElementById('sample');

if (element) {
    Util.on(element, 'click', (e) => { ... });
}
```