### PR TITLE
Fix origin modifier for programmatically triggered animations

### DIFF
--- a/src/js/util/dom.js
+++ b/src/js/util/dom.js
@@ -99,7 +99,7 @@ export function animate(element, animation, duration = 200, origin, out) {
             if (startsWith(animation, animationPrefix)) {
 
                 if (origin) {
-                    cls += ` ${animationPrefix}${origin}`;
+                    cls += ` uk-transform-origin-${origin}`;
                 }
 
                 if (out) {


### PR DESCRIPTION
Right now if you pass an origin modifier to `UIkit.util.animate()` it gets prefixed with `uk-animation-`, which is [according to the docs](https://getuikit.com/docs/animation#origin-modifiers) wrong.

**Example:**
```js
// Programmatically animate something
UIkit.util.animate(element, 'uk-animation-scale-up', 400, 'bottom-right', false);
```

```html
<!-- Generated HTML -->
<div class="uk-animation-scale-up uk-animation-enter uk-animation-bottom-right"></div>

<!-- Should generate the following-->
<div class="uk-animation-scale-up uk-animation-enter uk-transform-origin-bottom-right"></div>
```