### PR TITLE
function matches (js/util/selector) support some android native browsers

### DIFF
--- a/src/js/util/selector.js
+++ b/src/js/util/selector.js
@@ -120,7 +120,7 @@ function isContextSelector(selector) {
 }
 
 var elProto = Element.prototype;
-var matchesFn = elProto.matches || elProto.msMatchesSelector;
+var matchesFn = elProto.matches || elProto.webkitMatchesSelector || elProto.msMatchesSelector;
 
 export function matches(element, selector) {
     return toNodes(element).some(element => matchesFn.call(element, selector));


### PR DESCRIPTION
On my android phone browser "Browser" Off-canvas and Modal does not work without this
