### PR TITLE
fix uk-height-match calculating offsets of nested target per row, #3098

### DIFF
--- a/src/js/core/height-match.js
+++ b/src/js/core/height-match.js
@@ -20,6 +20,10 @@ export default function (UIkit) {
 
             elements({target}, $el) {
                 return $$(target, $el);
+            },
+
+            parentElements: function elements(ref, $el) {
+                return $$('> *', $el);
             }
 
         },
@@ -32,15 +36,18 @@ export default function (UIkit) {
 
                 css(this.elements, 'minHeight', '');
 
+                const checkParents = this.target !== '> *';
+                const elements = checkParents ? this.parentElements : this.elements;
+
                 return {
                     rows: !this.row
                         ? [this.match(this.elements)]
-                        : this.elements.reduce((rows, el) => {
+                        : elements.reduce((rows, el, index) => {
 
                             if (lastOffset !== el.offsetTop) {
-                                rows.push([el]);
+                                rows.push([checkParents ? this.elements[index] : el]);
                             } else {
-                                rows[rows.length - 1].push(el);
+                                rows[rows.length - 1].push(checkParents ? this.elements[index] : el);
                             }
 
                             lastOffset = el.offsetTop;


### PR DESCRIPTION
Hey folks,

here is a proposal to fix #3098. I tracked the issue down to the `height-match.read` function not being able to return the correct rows, when a custon `target` was set. It always returns only 1 row, even if you have like 6 cards in 2 rows. That's because of the way how rows are recognized in the following lines:

https://github.com/uikit/uikit/blob/4ef08ce29a3c82c1c78bef2a25b102f5a2cb23af/src/js/core/height-match.js#L38-L48

When the default target was set `> * ` it works fine, but having a target like `> div > .uk-card-title` causes an issue, because `el.offsetTop` is always the same value (the offset between `div` and `.uk-card-title`) and does not reflect the actual offset to the parent element that is used to wrap elements into rows.

So in this fix, the offset calculation is being made with the default targets `> * ` to seperate the custom target element by rows correctly. It now works as intended for me.

And thanks for ui-kit, just found it recently and it really turns out great 👍 