### PR TITLE
Fix error message for maxSize option

### DIFF
--- a/src/js/components/upload.js
+++ b/src/js/components/upload.js
@@ -28,7 +28,7 @@ export default {
         mime: false,
         msgInvalidMime: 'Invalid File Type: %s',
         msgInvalidName: 'Invalid File Name: %s',
-        msgInvalidSize: 'Invalid File Size: %s Bytes Max',
+        msgInvalidSize: 'Invalid File Size: %s Kilobytes Max',
         multiple: false,
         name: 'files[]',
         params: {},
@@ -107,7 +107,7 @@ export default {
             for (let i = 0; i < files.length; i++) {
 
                 if (this.maxSize && this.maxSize * 1000 < files[i].size) {
-                    this.fail(this.msgInvalidSize.replace('%s', this.allow));
+                    this.fail(this.msgInvalidSize.replace('%s', this.maxSize));
                     return;
                 }
 


### PR DESCRIPTION
## Current behaviour

```log
Invalid File Size: *.jpeg Bytes Max
```

## Expected behaviour

```log
Invalid File Size: 1000 Kilobytes Max
```

## Why Kilobyte?

On [line 115](https://github.com/uikit/uikit/blob/develop/src/js/components/upload.js#L115) `maxSize` gets multiplied by a factor of 1000 and [1000 Bytes = 1 Kilobyte](https://www.google.ch/search?q=1+kilobyte).