### PR TITLE
add uk-text-italic font style modifier

### DIFF
--- a/src/less/components/text.less
+++ b/src/less/components/text.less
@@ -80,6 +80,12 @@
 .uk-text-bold { font-weight: @text-bold-font-weight; }
 
 
+/* Font style modifier
+ ========================================================================== */
+
+.uk-text-italic { font-style: italic; }
+
+
 /* Transform modifier
  ========================================================================== */
 

--- a/src/scss/components/text.scss
+++ b/src/scss/components/text.scss
@@ -80,6 +80,12 @@ $text-background-color:                          $global-primary-background !def
 .uk-text-bold { font-weight: $text-bold-font-weight; }
 
 
+/* Font style modifier
+ ========================================================================== */
+
+.uk-text-italic { font-style: italic; }
+
+
 /* Transform modifier
  ========================================================================== */
 


### PR DESCRIPTION
Since `uk-text-bold` exists, developers might assume that `uk-text-italic` exists as well and mistakenly use it. This change helps keep the selectors consistent.

This PR closes #3004