### PR TITLE
fix: `uk-img` is unable to load url with parenthesis

### DIFF
--- a/src/js/core/img.js
+++ b/src/js/core/img.js
@@ -129,7 +129,7 @@ function setSrcAttrs(el, src, srcset, sizes) {
 
         const change = !includes(el.style.backgroundImage, src);
         if (change) {
-            css(el, 'backgroundImage', `url(${src})`);
+            css(el, 'backgroundImage', `url("${src}")`);
             trigger(el, createEvent('load', false));
         }
 


### PR DESCRIPTION
Here is an issue similar with [this stackoverflow question](https://stackoverflow.com/questions/29552317/using-image-url-with-parentheses-as-background-with-jquery). This pr fix it.