### PR TITLE
Fixed offcanvas light and dark color modes

### DIFF
--- a/src/less/components/offcanvas.less
+++ b/src/less/components/offcanvas.less
@@ -28,7 +28,7 @@
 @offcanvas-bar-width:                           270px;
 @offcanvas-bar-padding-vertical:                @global-margin;
 @offcanvas-bar-padding-horizontal:              @global-margin;
-@offcanvas-bar-background:                      @global-secondary-background;
+@offcanvas-bar-background:                      @global-background;
 @offcanvas-bar-color-mode:                      light;
 
 @offcanvas-bar-width-m:                         350px;
@@ -109,8 +109,8 @@
 }
 
 // Color Mode
-.uk-offcanvas-bar:extend(.uk-light all) when (@offcanvas-bar-color-mode = light) {}
-.uk-offcanvas-bar:extend(.uk-dark all) when (@offcanvas-bar-color-mode = dark) {}
+.uk-offcanvas-bar:extend(.uk-light all) when (@offcanvas-bar-color-mode = dark) {}
+.uk-offcanvas-bar:extend(.uk-dark all) when (@offcanvas-bar-color-mode = light) {}
 
 /* Flip modifier */
 .uk-offcanvas-flip .uk-offcanvas-bar {
@@ -304,3 +304,17 @@
 .hook-offcanvas-close() {}
 .hook-offcanvas-overlay() {}
 .hook-offcanvas-misc() {}
+
+
+// Inverse
+// ========================================================================
+
+@inverse-offcanvas-bar-background:              @global-secondary-background;
+
+.hook-inverse() {
+
+    .uk-offcanvas-bar {
+        background: @inverse-offcanvas-bar-background;
+    }
+
+}


### PR DESCRIPTION
- There was a bug that makes the default color mode which is (light text - dark background) permanent and can't be reversed using .uk-light or .uk-dark classes.
- After this fix, the default color mode is (dark text - light background) and can revered to (light text - dark background) using .uk-light class.