### PR TITLE
Possible fix for Safari 12 syntax issue w/ leader content

### DIFF
--- a/src/less/components/leader.less
+++ b/src/less/components/leader.less
@@ -50,7 +50,7 @@
  */
 
 .uk-leader-fill-content::before { content: '@{leader-fill-content}'; }
-:root { --uk-leader-fill-content: @leader-fill-content; }
+:root { --uk-leader-fill-content: '@{leader-fill-content}'; }
 
 
 // Hooks


### PR DESCRIPTION
The content of the CSS literal value needs to be quoted for Safari 12.