### PR TITLE
feat: Lightbox supports WebP images

### DIFF
--- a/src/js/components/lightbox-panel.js
+++ b/src/js/components/lightbox-panel.js
@@ -219,7 +219,7 @@ export default {
                 let matches;
 
                 // Image
-                if (type === 'image' || source.match(/\.(jp(e)?g|png|gif|svg)($|\?)/i)) {
+                if (type === 'image' || source.match(/\.(jp(e)?g|png|gif|svg|webp)($|\?)/i)) {
 
                     getImage(source).then(
                         img => this.setItem(item, `<img width="${img.width}" height="${img.height}" src="${source}" alt="${alt ? alt : ''}">`),


### PR DESCRIPTION
The Lightbox component now considers WebP images as image type.