### PR TITLE
fix(icon): make SVG icons non-focusable in IE

### DIFF
--- a/src/js/core/icon.js
+++ b/src/js/core/icon.js
@@ -48,7 +48,9 @@ const Icon = {
 
     props: ['icon'],
 
-    data: {include: []},
+    data: {
+        include: ['focusable']
+    },
 
     isIcon: true,
 

--- a/src/js/core/svg.js
+++ b/src/js/core/svg.js
@@ -14,6 +14,7 @@ export default {
         ratio: Number,
         'class': String,
         strokeAnimation: Boolean,
+        focusable: Boolean,
         attributes: 'list'
     },
 
@@ -21,7 +22,8 @@ export default {
         ratio: 1,
         include: ['style', 'class'],
         'class': '',
-        strokeAnimation: false
+        strokeAnimation: false,
+        focusable: 'false'
     },
 
     connected() {


### PR DESCRIPTION
* https://github.com/PolymerElements/iron-iconset-svg/issues/46
* https://allyjs.io/tutorials/focusing-in-svg.html