### PR TITLE
feat: add 'password' option for modal prompt input

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -119,7 +119,7 @@ function install(UIkit) {
 
     UIkit.modal.prompt = function (message, value, options) {
 
-        options = assign({bgClose: false, escClose: true, labels: UIkit.modal.labels}, options);
+        options = assign({bgClose: false, escClose: true, labels: UIkit.modal.labels, password: false}, options);
 
         return new Promise(resolve => {
 
@@ -127,7 +127,7 @@ function install(UIkit) {
                     <form class="uk-form-stacked">
                         <div class="uk-modal-body">
                             <label>${isString(message) ? message : html(message)}</label>
-                            <input class="uk-input" autofocus>
+                            <input class="uk-input" ${options.password === true ? 'type="password"' : ''}autofocus>
                         </div>
                         <div class="uk-modal-footer uk-text-right">
                             <button class="uk-button uk-button-default uk-modal-close" type="button">${options.labels.cancel}</button>


### PR DESCRIPTION
Adding `password` option (boolean) for the `UIkit.modal.prompt()` component.

E.g.,

```
UIkit.modal.prompt('message', '', {password: true})
```

<img width="623" alt="Screen Shot 2019-07-05 at 17 26 32" src="https://user-images.githubusercontent.com/11495867/60709024-63aa1d00-9f4a-11e9-823c-8b089419228a.png">
