### PR TITLE
feat: Lightbox image srcset

### DIFF
--- a/src/js/components/lightbox-panel.js
+++ b/src/js/components/lightbox-panel.js
@@ -216,7 +216,7 @@ export default {
 
             handler(_, item) {
 
-                const {source, type, alt} = item;
+                const {source, type, alt, srcset} = item;
 
                 this.setItem(item, '<span uk-spinner></span>');
 
@@ -229,8 +229,8 @@ export default {
                 // Image
                 if (type === 'image' || source.match(/\.(jp(e)?g|png|gif|svg|webp)($|\?)/i)) {
 
-                    getImage(source).then(
-                        img => this.setItem(item, `<img width="${img.width}" height="${img.height}" src="${source}" alt="${alt ? alt : ''}">`),
+                    getImage(source, srcset).then(
+                        img => this.setItem(item, `<img width="${img.width}" height="${img.height}" src="${source}" alt="${alt ? alt : ''}" srcset="${srcset ? srcset : ''}">`),
                         () => this.setError(item)
                     );
 

--- a/src/js/components/lightbox.js
+++ b/src/js/components/lightbox.js
@@ -89,7 +89,7 @@ function install(UIkit, Lightbox) {
 }
 
 function toItem(el) {
-    return ['href', 'caption', 'type', 'poster', 'alt'].reduce((obj, attr) => {
+    return ['href', 'caption', 'type', 'poster', 'alt', 'srcset'].reduce((obj, attr) => {
         obj[attr === 'href' ? 'source' : attr] = data(el, attr);
         return obj;
     }, {});


### PR DESCRIPTION
Add easy `srcset` configuration for Lightbox images.
Just add `data-srcset` options to the anchor tag.
`href` will remain as `src` fallback.

There's no need for `sizes` attribute as images will try to load on default 100vw

```html
<div uk-lightbox>
    <a href="image1.jpg" data-srcset="image1.webp 2000w, image2.webp 1440w, etc"></a>
</div>
```