### PR TITLE
feat: add uk-container-break

### DIFF
--- a/src/less/components/container.less
+++ b/src/less/components/container.less
@@ -46,10 +46,25 @@
     padding-right: @container-padding-horizontal;
 }
 
+.uk-container-break {
+    width: calc(100% + (@container-padding-horizontal * 2));
+    margin-left: -@container-padding-horizontal;
+}
+
 /* Phone landscape and bigger */
 @media (min-width: @breakpoint-small) {
 
     .uk-container {
+        padding-left: @container-padding-horizontal-s;
+        padding-right: @container-padding-horizontal-s;
+    }
+
+    .uk-container-break {
+        width: calc(100% + (@container-padding-horizontal-s * 2));
+        margin-left: -@container-padding-horizontal-s;
+    }
+
+    .uk-container .uk-container-break .uk-container {
         padding-left: @container-padding-horizontal-s;
         padding-right: @container-padding-horizontal-s;
     }
@@ -60,6 +75,16 @@
 @media (min-width: @breakpoint-medium) {
 
     .uk-container {
+        padding-left: @container-padding-horizontal-m;
+        padding-right: @container-padding-horizontal-m;
+    }
+
+    .uk-container-break {
+        width: calc(100% + (@container-padding-horizontal-m * 2));
+        margin-left: -@container-padding-horizontal-m;
+    }
+
+    .uk-container .uk-container-break .uk-container {
         padding-left: @container-padding-horizontal-m;
         padding-right: @container-padding-horizontal-m;
     }
@@ -91,6 +116,10 @@
 .uk-container .uk-container {
     padding-left: 0;
     padding-right: 0;
+}
+.uk-container .uk-container-break .uk-container {
+    padding-left: @container-padding-horizontal;
+    padding-right: @container-padding-horizontal;
 }
 
 

--- a/src/scss/components/container.scss
+++ b/src/scss/components/container.scss
@@ -46,10 +46,25 @@ $container-padding-horizontal-m:         $global-medium-gutter !default;
     padding-right: $container-padding-horizontal;
 }
 
+.uk-container-break {
+    width: calc(100% + ($container-padding-horizontal * 2));
+    margin-left: -$container-padding-horizontal;
+}
+
 /* Phone landscape and bigger */
 @media (min-width: $breakpoint-small) {
 
     .uk-container {
+        padding-left: $container-padding-horizontal-s;
+        padding-right: $container-padding-horizontal-s;
+    }
+
+    .uk-container-break {
+        width: calc(100% + ($container-padding-horizontal-s * 2));
+        margin-left: -$container-padding-horizontal-s;
+    }
+
+    .uk-container .uk-container-break .uk-container {
         padding-left: $container-padding-horizontal-s;
         padding-right: $container-padding-horizontal-s;
     }
@@ -60,6 +75,16 @@ $container-padding-horizontal-m:         $global-medium-gutter !default;
 @media (min-width: $breakpoint-medium) {
 
     .uk-container {
+        padding-left: $container-padding-horizontal-m;
+        padding-right: $container-padding-horizontal-m;
+    }
+
+    .uk-container-break {
+        width: calc(100% + ($container-padding-horizontal-m * 2));
+        margin-left: -$container-padding-horizontal-m;
+    }
+
+    .uk-container .uk-container-break .uk-container {
         padding-left: $container-padding-horizontal-m;
         padding-right: $container-padding-horizontal-m;
     }


### PR DESCRIPTION
Creates a .uk-container-break component to allow elements to break out of their containers.

This would be useful to allow a single .uk-container element be used on a page, but to allow elements to occasionally break out to create full-width background elements.

potential CSS solution to #3923 