### PR TITLE
Fix for issue #2275

### DIFF
--- a/src/js/components/sticky.js
+++ b/src/js/components/sticky.js
@@ -245,7 +245,7 @@
 
             if (this.element.css('position') == 'fixed') {
                 this.element.css({
-                    width: this.sticky.getWidthFrom.length ? this.sticky.getWidthFrom.width() : this.element.width()
+                    width: this.sticky && this.sticky.getWidthFrom.length ? this.sticky.getWidthFrom.width() : this.element.width()
                 });
             }
         }


### PR DESCRIPTION
src/js/components/sticky.js
- check if this.sticky is defined before accessing in computeWrapper() (this.sticky is only setup in init() AFTER calling computeWrapper(), but there is a code path in computeWrapper() that expects it to be defined already)