### PR TITLE
Fix truncating table cells for iOS <= 10

### DIFF
--- a/src/less/components/text.less
+++ b/src/less/components/text.less
@@ -79,14 +79,14 @@
 .uk-text-light { font-weight: 300; }
 .uk-text-normal { font-weight: 400; }
 .uk-text-bold { font-weight: 700; }
- 
+
 .uk-text-lighter { font-weight: lighter; }
 .uk-text-bolder { font-weight: bolder; }
 
- 
+
 /* Style modifier
  ========================================================================== */
- 
+
 .uk-text-italic { font-style: italic; }
 
 
@@ -218,9 +218,9 @@
     white-space: nowrap;
 }
 
-/* 2 */
+/* 3 */
 th.uk-text-truncate,
-td.uk-text-truncate { max-width: 0; }
+td.uk-text-truncate { max-width: none; }
 
 
 /*

--- a/src/scss/components/text.scss
+++ b/src/scss/components/text.scss
@@ -79,14 +79,14 @@ $text-background-color:                          $global-primary-background !def
 .uk-text-light { font-weight: 300; }
 .uk-text-normal { font-weight: 400; }
 .uk-text-bold { font-weight: 700; }
- 
+
 .uk-text-lighter { font-weight: lighter; }
 .uk-text-bolder { font-weight: bolder; }
 
- 
+
 /* Style modifier
  ========================================================================== */
- 
+
 .uk-text-italic { font-style: italic; }
 
 
@@ -218,9 +218,9 @@ $text-background-color:                          $global-primary-background !def
     white-space: nowrap;
 }
 
-/* 2 */
+/* 3 */
 th.uk-text-truncate,
-td.uk-text-truncate { max-width: 0; }
+td.uk-text-truncate { max-width: none; }
 
 
 /*


### PR DESCRIPTION
This fixes the display of truncated table cells for iOS <= 10.

**Before:**
![before](https://user-images.githubusercontent.com/17384333/69351512-bc6d1e80-0c7b-11ea-8b6c-33073c3be1f1.jpg)

**After:**
![after](https://user-images.githubusercontent.com/17384333/69351530-c131d280-0c7b-11ea-9bb6-1154b65692aa.jpg)

PS: Sorry for the removal of the redundant spaces, my IDE does that automatically.