### PR TITLE
fix svg parallax fail when element is not visible

### DIFF
--- a/src/js/core/svg.js
+++ b/src/js/core/svg.js
@@ -198,6 +198,9 @@ function applyAnimation(el) {
 }
 
 export function getMaxPathLength(el) {
+    if (!isVisible(el)) {
+        return;
+    }
     return Math.ceil(Math.max(...$$('[stroke]', el).map(stroke =>
         stroke.getTotalLength && stroke.getTotalLength() || 0
     ).concat([0])));


### PR DESCRIPTION
This fixes #4132 .
The error was caused due to `svg` element not being rendered. Added a condition to check if the element is visible.