### PR TITLE
UIKit 4: Start using logical properties

### DIFF
--- a/src/scss/components/tab.scss
+++ b/src/scss/components/tab.scss
@@ -145,12 +145,12 @@ $tab-item-disabled-color:                 $global-muted-color !default;
 }
 
 .uk-tab-left > * > a {
-    text-align: left;
+    text-align: start;
     @if(mixin-exists(hook-tab-left-item)) {@include hook-tab-left-item();}
 }
 
 .uk-tab-right > * > a {
-    text-align: left;
+    text-align: start;
     @if(mixin-exists(hook-tab-right-item)) {@include hook-tab-right-item();}
 }
 

--- a/src/scss/components/table.scss
+++ b/src/scss/components/table.scss
@@ -88,7 +88,7 @@ $table-expand-min-width:                         150px !default;
 
 .uk-table th {
     padding: $table-cell-padding-vertical $table-cell-padding-horizontal;
-    text-align: left;
+    text-align: start;
     vertical-align: bottom;
     /* 1 */
     font-size: $table-header-cell-font-size;
@@ -128,7 +128,7 @@ $table-expand-min-width:                         150px !default;
 
 .uk-table caption {
     font-size: $table-caption-font-size;
-    text-align: left;
+    text-align: start;
     color: $table-caption-color;
     @if(mixin-exists(hook-table-caption)) {@include hook-table-caption();}
 }

--- a/src/scss/components/text.scss
+++ b/src/scss/components/text.scss
@@ -143,16 +143,16 @@ $text-background-color:                          $global-primary-background !def
 /* Alignment modifiers
  ========================================================================== */
 
-.uk-text-left { text-align: left !important; }
-.uk-text-right { text-align: right !important; }
+.uk-text-start { text-align: start !important; }
+.uk-text-end { text-align: end !important; }
 .uk-text-center { text-align: center !important; }
 .uk-text-justify { text-align: justify !important; }
 
 /* Phone landscape and bigger */
 @media (min-width: $breakpoint-small) {
 
-    .uk-text-left\@s { text-align: left !important; }
-    .uk-text-right\@s { text-align: right !important; }
+    .uk-text-start\@s { text-align: start !important; }
+    .uk-text-end\@s { text-align: end !important; }
     .uk-text-center\@s { text-align: center !important; }
 
 }
@@ -160,8 +160,8 @@ $text-background-color:                          $global-primary-background !def
 /* Tablet landscape and bigger */
 @media (min-width: $breakpoint-medium) {
 
-    .uk-text-left\@m { text-align: left !important; }
-    .uk-text-right\@m { text-align: right !important; }
+    .uk-text-start\@m { text-align: start !important; }
+    .uk-text-end\@m { text-align: end !important; }
     .uk-text-center\@m { text-align: center !important; }
 
 }
@@ -169,8 +169,8 @@ $text-background-color:                          $global-primary-background !def
 /* Desktop and bigger */
 @media (min-width: $breakpoint-large) {
 
-    .uk-text-left\@l { text-align: left !important; }
-    .uk-text-right\@l { text-align: right !important; }
+    .uk-text-start\@l { text-align: start !important; }
+    .uk-text-end\@l { text-align: end !important; }
     .uk-text-center\@l { text-align: center !important; }
 
 }
@@ -178,8 +178,8 @@ $text-background-color:                          $global-primary-background !def
 /* Large screen and bigger */
 @media (min-width: $breakpoint-xlarge) {
 
-    .uk-text-left\@xl { text-align: left !important; }
-    .uk-text-right\@xl { text-align: right !important; }
+    .uk-text-start\@xl { text-align: start !important; }
+    .uk-text-end\@xl { text-align: end !important; }
     .uk-text-center\@xl { text-align: center !important; }
 
 }


### PR DESCRIPTION
Assuming UIKit 4 will not support IE11, this PR replaces `left` and `right` text alignments with `start` and `end`.

The benefit of this is that properties do not need to be reversed for RTL mode...it's done automatically by the browser.

If this is accepted, I'll be more than happy to start working on other logical properties, such as:

- margin
- padding
- border

There are certain logical properties that are still unsuupported (mainly by Safari), but I reckon they'll start supporting them in the not too distant future