### PR TITLE
Responsive table: add tfoot selector

### DIFF
--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -244,7 +244,7 @@
 
     .uk-table-responsive,
     .uk-table-responsive tbody,
-    .uk-table-responsove tfoot,
+    .uk-table-responsive tfoot,
     .uk-table-responsive th,
     .uk-table-responsive td,
     .uk-table-responsive tr { display: block; }

--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -244,6 +244,7 @@
 
     .uk-table-responsive,
     .uk-table-responsive tbody,
+    .uk-table-responsove tfoot,
     .uk-table-responsive th,
     .uk-table-responsive td,
     .uk-table-responsive tr { display: block; }


### PR DESCRIPTION
When using responsive table `<tfoot>` element doesn't expand to full width like `<tbody>` element does.

PS: 
GitHub Editor removed newline at the end of file