### PR TITLE
Fix error thrown by empty sliders

### DIFF
--- a/src/js/components/slider.js
+++ b/src/js/components/slider.js
@@ -126,11 +126,12 @@ export default {
                 this.reorder();
                 this._translate(1);
             }
-
-            const actives = this._getTransitioner(this.index).getActives();
-            this.slides.forEach(slide => toggleClass(slide, this.clsActive, includes(actives, slide)));
-            (!this.sets || includes(this.sets, toFloat(this.index))) && this.slides.forEach(slide => toggleClass(slide, this.clsActivated, includes(actives, slide)));
-
+            
+            if (this.length) {
+                const actives = this._getTransitioner(this.index).getActives();
+                this.slides.forEach(slide => toggleClass(slide, this.clsActive, includes(actives, slide)));
+                (!this.sets || includes(this.sets, toFloat(this.index))) && this.slides.forEach(slide => toggleClass(slide, this.clsActivated, includes(actives, slide)));
+            }
         },
 
         events: ['resize']


### PR DESCRIPTION
Empty sliders cause an error due to the resize handler trying to apply active states. The error can be avoided by checking for the existence of items beforehand.