### PR TITLE
[Navbar] Ignore Dropdown events, if drop does not have correct class

### DIFF
--- a/src/js/core/navbar.js
+++ b/src/js/core/navbar.js
@@ -1,6 +1,6 @@
 import Class from '../mixin/class';
 import FlexBug from '../mixin/flex-bug';
-import {$, $$, addClass, after, assign, css, height, includes, isRtl, isVisible, matches, noop, Promise, query, remove, toFloat, Transition, within} from 'uikit-util';
+import {$, $$, addClass, after, assign, css, hasClass, height, includes, isRtl, isVisible, matches, noop, Promise, query, remove, toFloat, Transition, within} from 'uikit-util';
 
 export default {
 
@@ -162,6 +162,9 @@ export default {
             },
 
             handler(_, {$el, dir}) {
+                if (!hasClass($el, this.clsDrop)) {
+                    return;
+                }
 
                 if (this.dropbarMode === 'slide') {
                     addClass(this.dropbar, 'uk-navbar-dropbar-slide');
@@ -200,6 +203,9 @@ export default {
             },
 
             handler(_, {$el}) {
+                if (!hasClass($el, this.clsDrop)) {
+                    return;
+                }
 
                 const active = this.getActive();
 


### PR DESCRIPTION
Before updating the dropbar on `show` / `hide`, we add a check if the dropdown has the correct class (`clsDrop`). With this unwanted height updates of the dropbar are prevented.

Resolves https://github.com/uikit/uikit/issues/4272