### PR TITLE
Correct styling of disabled buttons in inverse mode

### DIFF
--- a/src/less/components/button.less
+++ b/src/less/components/button.less
@@ -538,8 +538,8 @@
         .hook-inverse-button-link;
     }
 
-    .uk-button-link:hover,
-    .uk-button-link:focus { color: @inverse-button-link-hover-color; }
+    .uk-button-link:hover:not(:disabled),
+    .uk-button-link:focus:not(:disabled) { color: @inverse-button-link-hover-color; }
 }
 
 .hook-inverse-button-default() {}

--- a/src/less/components/button.less
+++ b/src/less/components/button.less
@@ -441,21 +441,21 @@
     // Default
     //
 
-    .uk-button-default {
+    .uk-button-default:not(:disabled) {
         background-color: @inverse-button-default-background;
         color: @inverse-button-default-color;
         .hook-inverse-button-default;
     }
 
-    .uk-button-default:hover,
-    .uk-button-default:focus {
+    .uk-button-default:hover:not(:disabled),
+    .uk-button-default:focus:not(:disabled) {
         background-color: @inverse-button-default-hover-background;
         color: @inverse-button-default-hover-color;
         .hook-inverse-button-default-hover;
     }
 
-    .uk-button-default:active,
-    .uk-button-default.uk-active {
+    .uk-button-default:active:not(:disabled),
+    .uk-button-default.uk-active:not(:disabled) {
         background-color: @inverse-button-default-active-background;
         color: @inverse-button-default-active-color;
         .hook-inverse-button-default-active;
@@ -465,21 +465,21 @@
     // Primary
     //
 
-    .uk-button-primary {
+    .uk-button-primary:not(:disabled) {
         background-color: @inverse-button-primary-background;
         color: @inverse-button-primary-color;
         .hook-inverse-button-primary;
     }
 
-    .uk-button-primary:hover,
-    .uk-button-primary:focus {
+    .uk-button-primary:hover:not(:disabled),
+    .uk-button-primary:focus:not(:disabled) {
         background-color: @inverse-button-primary-hover-background;
         color: @inverse-button-primary-hover-color;
         .hook-inverse-button-primary-hover;
     }
 
-    .uk-button-primary:active,
-    .uk-button-primary.uk-active {
+    .uk-button-primary:active:not(:disabled),
+    .uk-button-primary.uk-active:not(:disabled) {
         background-color: @inverse-button-primary-active-background;
         color: @inverse-button-primary-active-color;
         .hook-inverse-button-primary-active;
@@ -489,21 +489,21 @@
     // Secondary
     //
 
-    .uk-button-secondary {
+    .uk-button-secondary:not(:disabled) {
         background-color: @inverse-button-secondary-background;
         color: @inverse-button-secondary-color;
         .hook-inverse-button-secondary;
     }
 
-    .uk-button-secondary:hover,
-    .uk-button-secondary:focus {
+    .uk-button-secondary:hover:not(:disabled),
+    .uk-button-secondary:focus:not(:disabled) {
         background-color: @inverse-button-secondary-hover-background;
         color: @inverse-button-secondary-hover-color;
         .hook-inverse-button-secondary-hover;
     }
 
-    .uk-button-secondary:active,
-    .uk-button-secondary.uk-active {
+    .uk-button-secondary:active:not(:disabled),
+    .uk-button-secondary.uk-active:not(:disabled) {
         background-color: @inverse-button-secondary-active-background;
         color: @inverse-button-secondary-active-color;
         .hook-inverse-button-secondary-active;
@@ -513,13 +513,13 @@
     // Text
     //
 
-    .uk-button-text {
+    .uk-button-text:not(:disabled) {
         color: @inverse-button-text-color;
         .hook-inverse-button-text;
     }
 
-    .uk-button-text:hover,
-    .uk-button-text:focus {
+    .uk-button-text:hover:not(:disabled),
+    .uk-button-text:focus:not(:disabled) {
         color: @inverse-button-text-hover-color;
         .hook-inverse-button-text-hover;
     }
@@ -533,15 +533,13 @@
     // Link
     //
 
-    .uk-button-link {
+    .uk-button-link:not(:disabled) {
         color: @inverse-button-link-color;
         .hook-inverse-button-link;
     }
 
     .uk-button-link:hover,
     .uk-button-link:focus { color: @inverse-button-link-hover-color; }
-
-
 }
 
 .hook-inverse-button-default() {}


### PR DESCRIPTION
The current implementation of `.hook-inverse()` for buttons fails to respect the disabled state when styling these in inverse mode. Also see issue #3890.