### PR TITLE
feat: Single column classes

### DIFF
--- a/src/less/components/column.less
+++ b/src/less/components/column.less
@@ -66,7 +66,8 @@
 /* Width modifiers
  ========================================================================== */
 
-.uk-column-1-2 { column-count: 2;}
+.uk-column-1-1 { column-count: 1; }
+.uk-column-1-2 { column-count: 2; }
 .uk-column-1-3 { column-count: 3; }
 .uk-column-1-4 { column-count: 4; }
 .uk-column-1-5 { column-count: 5; }
@@ -75,6 +76,7 @@
 /* Phone landscape and bigger */
 @media (min-width: @breakpoint-small) {
 
+    .uk-column-1-1\@s { column-count: 1; }
     .uk-column-1-2\@s { column-count: 2; }
     .uk-column-1-3\@s { column-count: 3; }
     .uk-column-1-4\@s { column-count: 4; }
@@ -86,6 +88,7 @@
 /* Tablet landscape and bigger */
 @media (min-width: @breakpoint-medium) {
 
+    .uk-column-1-1\@m { column-count: 1; }
     .uk-column-1-2\@m { column-count: 2; }
     .uk-column-1-3\@m { column-count: 3; }
     .uk-column-1-4\@m { column-count: 4; }
@@ -97,6 +100,7 @@
 /* Desktop and bigger */
 @media (min-width: @breakpoint-large) {
 
+    .uk-column-1-1\@l { column-count: 1; }
     .uk-column-1-2\@l { column-count: 2; }
     .uk-column-1-3\@l { column-count: 3; }
     .uk-column-1-4\@l { column-count: 4; }
@@ -108,6 +112,7 @@
 /* Large screen and bigger */
 @media (min-width: @breakpoint-xlarge) {
 
+    .uk-column-1-1\@xl { column-count: 1; }
     .uk-column-1-2\@xl { column-count: 2; }
     .uk-column-1-3\@xl { column-count: 3; }
     .uk-column-1-4\@xl { column-count: 4; }

--- a/src/scss/components/column.scss
+++ b/src/scss/components/column.scss
@@ -66,7 +66,8 @@ $column-divider-rule-width:                      1px !default;
 /* Width modifiers
  ========================================================================== */
 
-.uk-column-1-2 { column-count: 2;}
+.uk-column-1-1 { column-count: 1; }
+.uk-column-1-2 { column-count: 2; }
 .uk-column-1-3 { column-count: 3; }
 .uk-column-1-4 { column-count: 4; }
 .uk-column-1-5 { column-count: 5; }
@@ -75,6 +76,7 @@ $column-divider-rule-width:                      1px !default;
 /* Phone landscape and bigger */
 @media (min-width: $breakpoint-small) {
 
+    .uk-column-1-1\@s { column-count: 1; }
     .uk-column-1-2\@s { column-count: 2; }
     .uk-column-1-3\@s { column-count: 3; }
     .uk-column-1-4\@s { column-count: 4; }
@@ -86,6 +88,7 @@ $column-divider-rule-width:                      1px !default;
 /* Tablet landscape and bigger */
 @media (min-width: $breakpoint-medium) {
 
+    .uk-column-1-1\@m { column-count: 1; }
     .uk-column-1-2\@m { column-count: 2; }
     .uk-column-1-3\@m { column-count: 3; }
     .uk-column-1-4\@m { column-count: 4; }
@@ -97,6 +100,7 @@ $column-divider-rule-width:                      1px !default;
 /* Desktop and bigger */
 @media (min-width: $breakpoint-large) {
 
+    .uk-column-1-1\@l { column-count: 1; }
     .uk-column-1-2\@l { column-count: 2; }
     .uk-column-1-3\@l { column-count: 3; }
     .uk-column-1-4\@l { column-count: 4; }
@@ -108,6 +112,7 @@ $column-divider-rule-width:                      1px !default;
 /* Large screen and bigger */
 @media (min-width: $breakpoint-xlarge) {
 
+    .uk-column-1-1\@xl { column-count: 1; }
     .uk-column-1-2\@xl { column-count: 2; }
     .uk-column-1-3\@xl { column-count: 3; }
     .uk-column-1-4\@xl { column-count: 4; }
@@ -135,4 +140,5 @@ $column-divider-rule-width:                      1px !default;
 // ========================================================================
 
 $inverse-column-divider-rule-color:                     $inverse-global-border !default;
+
 


### PR DESCRIPTION
Adds a single column class `.uk-column-1-1` to allow for reflow of multiple columns back into a single column at different breakpoints.

For example: if our container width changes from 1 to 1/4 as viewport width increases, we can reflow from 3 columns back to 1 with `uk-column-1-3 uk-column-1-1@l`