### PR TITLE
Add MIME-type icons

### DIFF
--- a/src/images/icons/file-epub.svg
+++ b/src/images/icons/file-epub.svg
@@ -5,15 +5,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="20"
    height="20"
    viewBox="0 0 20 20"
    version="1.1"
-   id="svg885"
-   sodipodi:docname="file-epub.svg"
-   inkscape:version="1.0.1 (1.0.1+r75)">
+   id="svg885">
   <metadata
      id="metadata891">
     <rdf:RDF>
@@ -22,7 +18,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -45,29 +41,6 @@
          id="path6" />
     </mask>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="1537"
-     id="namedview887"
-     showgrid="false"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:zoom="6.0059882"
-     inkscape:cx="-4.7160668"
-     inkscape:cy="2.5036926"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg885"
-     inkscape:document-rotation="0" />
   <rect
      fill="none"
      stroke="#000"

--- a/src/images/icons/file-epub.svg
+++ b/src/images/icons/file-epub.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg885"
+   sodipodi:docname="file-epub.svg"
+   inkscape:version="1.0.1 (1.0.1+r75)">
+  <metadata
+     id="metadata891">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs889">
+    <mask
+       id="mask">
+      <rect
+         style="fill:#ffffff"
+         width="100%"
+         height="100%"
+         id="rect2"
+         x="0"
+         y="0" />
+      <path
+         d="M 30,98 V 30 H 50 L 70,55 90,30 h 20 V 98 H 90 V 59 L 70,84 50,59 v 39 z"
+         id="path4" />
+      <path
+         d="M 155,98 125,65 h 20 V 30 h 20 v 35 h 20 z"
+         id="path6" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1537"
+     id="namedview887"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="6.0059882"
+     inkscape:cx="-4.7160668"
+     inkscape:cy="2.5036926"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg885"
+     inkscape:document-rotation="0" />
+  <rect
+     fill="none"
+     stroke="#000"
+     width="13"
+     height="17"
+     x="3.5"
+     y="1.5"
+     id="rect881" />
+  <path
+     id="rect1739"
+     style="fill:#000000;fill-opacity:0.97931;stroke:none;stroke-width:0.147452;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers stroke fill"
+     d="m 10.551732,6.1289204 c -0.305659,-0.3056595 -0.7978046,-0.3056595 -1.1034642,0 L 4.9492797,10.627909 c -0.3056595,0.305659 -0.3056595,0.797804 0,1.103463 l 4.498988,4.498989 c 0.3056596,0.305659 0.7978053,0.305659 1.1034643,0 l 4.498989,-4.498988 c 0.305659,-0.30566 0.305659,-0.797805 0,-1.103464 L 14.467739,10.044926 10.002155,14.510508 6.6540459,11.162399 10.015086,7.8013586 11.119629,8.9059005 8.8469658,11.178563 9.9827583,12.314355 13.359963,8.9371511 Z" />
+</svg>

--- a/src/images/icons/file-md.svg
+++ b/src/images/icons/file-md.svg
@@ -5,15 +5,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="20"
    height="20"
    viewBox="0 0 20 20"
    version="1.1"
-   id="svg885"
-   sodipodi:docname="file-md.svg"
-   inkscape:version="1.0.1 (1.0.1+r75)">
+   id="svg885">
   <metadata
      id="metadata891">
     <rdf:RDF>
@@ -45,28 +41,6 @@
          id="path6" />
     </mask>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="1537"
-     id="namedview887"
-     showgrid="false"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:zoom="33.975"
-     inkscape:cx="10"
-     inkscape:cy="8.390374"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg885" />
   <rect
      style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.188976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
      id="rect990"

--- a/src/images/icons/file-md.svg
+++ b/src/images/icons/file-md.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg885"
+   sodipodi:docname="file-md.svg"
+   inkscape:version="1.0.1 (1.0.1+r75)">
+  <metadata
+     id="metadata891">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs889">
+    <mask
+       id="mask">
+      <rect
+         style="fill:#ffffff"
+         width="100%"
+         height="100%"
+         id="rect2"
+         x="0"
+         y="0" />
+      <path
+         d="M 30,98 V 30 H 50 L 70,55 90,30 h 20 V 98 H 90 V 59 L 70,84 50,59 v 39 z"
+         id="path4" />
+      <path
+         d="M 155,98 125,65 h 20 V 30 h 20 v 35 h 20 z"
+         id="path6" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1537"
+     id="namedview887"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="33.975"
+     inkscape:cx="10"
+     inkscape:cy="8.390374"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg885" />
+  <rect
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.188976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect990"
+     width="13.223725"
+     height="5.6877112"
+     x="3.4935949"
+     y="9.2813578" />
+  <rect
+     fill="none"
+     stroke="#000"
+     width="13"
+     height="17"
+     x="3.5"
+     y="1.5"
+     id="rect881" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#fffffd;stroke-width:0.188976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 6.7106548,14.332969 V 12.00773 l 1.1928866,1.464312 1.2200573,-1.464312 v 2.325239 H 10.318845 V 10.212292 H 9.1235987 L 7.9035414,11.720754 6.7106548,10.212292 H 5.5004557 v 4.120677 z"
+     id="path976" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.188976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.458361,12.390364 v -2.178072 h 1.192053 v 2.178072 h 1.199412 l -1.810155,1.942605 -1.766004,-1.942605 z"
+     id="path978" />
+</svg>

--- a/src/images/icons/file-txt.svg
+++ b/src/images/icons/file-txt.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg885"
+   sodipodi:docname="file-txt.svg"
+   inkscape:version="1.0.1 (1.0.1+r75)">
+  <metadata
+     id="metadata891">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs889">
+    <mask
+       id="mask">
+      <rect
+         style="fill:#ffffff"
+         width="100%"
+         height="100%"
+         id="rect2"
+         x="0"
+         y="0" />
+      <path
+         d="M 30,98 V 30 H 50 L 70,55 90,30 h 20 V 98 H 90 V 59 L 70,84 50,59 v 39 z"
+         id="path4" />
+      <path
+         d="M 155,98 125,65 h 20 V 30 h 20 v 35 h 20 z"
+         id="path6" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1537"
+     id="namedview887"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="6.0059882"
+     inkscape:cx="10"
+     inkscape:cy="3.6810289"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg885" />
+  <rect
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.188976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+     id="rect990"
+     width="13.223725"
+     height="5.6877112"
+     x="3.4935949"
+     y="9.2813578" />
+  <rect
+     fill="none"
+     stroke="#000"
+     width="13"
+     height="17"
+     x="3.5"
+     y="1.5"
+     id="rect881" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#fffffd;stroke-width:0.188976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M -19.150776,10.151146 V 7.825907 l 1.192887,1.464312 1.220057,-1.464312 v 2.325239 h 1.195247 V 6.030469 h -1.195247 l -1.220057,1.508462 -1.192887,-1.508462 h -1.210199 v 4.120677 z"
+     id="path976-7" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.188976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M -13.403069,8.208541 V 6.030469 h 1.192053 v 2.178072 h 1.199412 l -1.810155,1.942605 -1.766004,-1.942605 z"
+     id="path978-5" />
+  <g
+     aria-label="txt"
+     id="text2368"
+     style="font-size:13.3333px;line-height:1.25;font-family:Bart;-inkscape-font-specification:Bart;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1"
+     transform="matrix(0.4825633,0,0,0.4825633,17.11137,14.493246)">
+    <path
+       d="m -24.476217,-8.2763289 q -0.221354,-0.2213536 -0.221354,-0.5338528 0,-0.3124993 0.221354,-0.5338529 0.221354,-0.2213536 0.533853,-0.2213536 h 4.40103 q 0.3125,0 0.533853,0.2213536 0.221354,0.2213536 0.221354,0.5338529 0,0.3124992 -0.221354,0.5338528 -0.221353,0.2148432 -0.533853,0.2148432 h -1.47135 v 7.07029462 q 0,0.31249921 -0.221354,0.53385281 -0.214843,0.21484321 -0.527342,0.21484321 -0.312499,0 -0.533853,-0.21484321 -0.221354,-0.2213536 -0.221354,-0.53385281 V -8.0614857 h -1.425777 q -0.312499,0 -0.533853,-0.2148432 z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Kohne Makina';-inkscape-font-specification:'Kohne Makina';fill:#ffffff;fill-opacity:1"
+       id="path2370" />
+    <path
+       d="m -17.392902,-0.75681668 q -0.03906,-0.1171872 -0.03906,-0.2343744 0,-0.16927042 0.08464,-0.33854082 l 1.78385,-3.5742097 -1.78385,-3.5742097 q -0.08464,-0.1692704 -0.08464,-0.3385408 0,-0.1171872 0.03906,-0.2343744 0.09766,-0.2929681 0.377603,-0.4361969 0.16276,-0.084635 0.332031,-0.084635 0.117187,0.00651 0.240885,0.045573 0.292968,0.1041664 0.436196,0.3776032 l 1.282549,2.5650977 1.282549,-2.5650977 q 0.143229,-0.2734368 0.436197,-0.3776032 0.123698,-0.039062 0.240885,-0.045573 0.16927,0 0.33203,0.084635 0.273437,0.1432288 0.377603,0.4361969 0.03906,0.1236976 0.04557,0.2408848 0,0.1692704 -0.08464,0.3320304 l -1.79036,3.5742097 1.79036,3.5742097 q 0.08464,0.16276 0.08464,0.33203042 -0.0065,0.1171872 -0.04557,0.2408848 -0.104166,0.29296801 -0.377603,0.43619682 -0.16927,0.0781248 -0.338541,0.0781248 -0.208332,0 -0.390624,-0.1106768 -0.182291,-0.11067681 -0.279947,-0.30598881 l -1.282549,-2.56509773 -1.282549,2.56509773 q -0.09766,0.195312 -0.279947,0.30598881 -0.182291,0.1106768 -0.390624,0.1106768 -0.16927,0 -0.338541,-0.0781248 -0.279947,-0.14322881 -0.377603,-0.43619682 z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Kohne Makina';-inkscape-font-specification:'Kohne Makina';fill:#ffffff;fill-opacity:1"
+       id="path2372" />
+    <path
+       d="m -10.465835,-8.2763289 q -0.221354,-0.2213536 -0.221354,-0.5338528 0,-0.3124993 0.221354,-0.5338529 0.221353,-0.2213536 0.5338526,-0.2213536 h 4.4010305 q 0.3124992,0 0.5338528,0.2213536 0.2213536,0.2213536 0.2213536,0.5338529 0,0.3124992 -0.2213536,0.5338528 -0.2213536,0.2148432 -0.5338528,0.2148432 h -1.4713505 v 7.07029462 q 0,0.31249921 -0.2213536,0.53385281 -0.2148432,0.21484321 -0.5273424,0.21484321 -0.3124992,0 -0.5338528,-0.21484321 -0.2213536,-0.2213536 -0.2213536,-0.53385281 V -8.0614857 h -1.4257776 q -0.3124996,0 -0.5338526,-0.2148432 z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Kohne Makina';-inkscape-font-specification:'Kohne Makina';fill:#ffffff;fill-opacity:1"
+       id="path2374" />
+  </g>
+</svg>

--- a/src/images/icons/file-txt.svg
+++ b/src/images/icons/file-txt.svg
@@ -5,15 +5,11 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="20"
    height="20"
    viewBox="0 0 20 20"
    version="1.1"
-   id="svg885"
-   sodipodi:docname="file-txt.svg"
-   inkscape:version="1.0.1 (1.0.1+r75)">
+   id="svg885">
   <metadata
      id="metadata891">
     <rdf:RDF>
@@ -45,28 +41,6 @@
          id="path6" />
     </mask>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="3840"
-     inkscape:window-height="1537"
-     id="namedview887"
-     showgrid="false"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:zoom="6.0059882"
-     inkscape:cx="10"
-     inkscape:cy="3.6810289"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg885" />
   <rect
      style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.188976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
      id="rect990"

--- a/src/images/icons/telegram.svg
+++ b/src/images/icons/telegram.svg
@@ -45,12 +45,4 @@
          id="path6" />
     </mask>
   </defs>
-  <rect
-     fill="none"
-     stroke="#000"
-     width="13"
-     height="17"
-     x="3.5"
-     y="1.5"
-     id="rect881" />
 </svg>

--- a/src/images/icons/telegram.svg
+++ b/src/images/icons/telegram.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg885">
+  <path
+     id="path1588"
+     style="fill:#000001;fill-opacity:1;stroke:none;stroke-width:0.085314;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 16.358353,2.4641554 c -0.07335,-0.012904 -0.147244,-0.00598 -0.212073,0.024235 L 0.98004186,8.3506931 C 0.6958676,8.4797094 0.53986859,8.8622316 1.0179142,9.1383938 l 3.6658307,1.3875602 1.4451252,4.577747 c 0.072254,0.237335 0.3590893,0.482733 0.6710597,0.227221 L 8.9388366,13.599499 C 9.081265,13.482194 9.3223039,13.368966 9.555362,13.575269 l 3.779442,2.756947 c 0.265895,0.14168 0.52073,0.05211 0.642278,-0.269634 L 16.709791,3.0685659 c 0.08,-0.3431169 -0.131363,-0.5657197 -0.351438,-0.6044078 z M 13.14848,5.3544057 c 0.110827,-0.017207 0.165914,0.07842 0.05151,0.2317655 L 7.4149414,10.986457 C 7.2499488,11.132968 6.9529488,11.45051 6.9089968,11.855956 l -0.1666287,1.410285 c -0.063186,0.323354 -0.331171,0.273148 -0.3893054,0.03483 L 5.6032334,10.685008 C 5.5076323,10.333865 5.5617002,10.063205 5.9319464,9.7640067 L 13.022754,5.4119668 c 0.04532,-0.032593 0.08878,-0.051825 0.125738,-0.057564 z" />
+  <metadata
+     id="metadata891">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs889">
+    <mask
+       id="mask">
+      <rect
+         style="fill:#ffffff"
+         width="100%"
+         height="100%"
+         id="rect2"
+         x="0"
+         y="0" />
+      <path
+         d="M 30,98 V 30 H 50 L 70,55 90,30 h 20 V 98 H 90 V 59 L 70,84 50,59 v 39 z"
+         id="path4" />
+      <path
+         d="M 155,98 125,65 h 20 V 30 h 20 v 35 h 20 z"
+         id="path6" />
+    </mask>
+  </defs>
+  <rect
+     fill="none"
+     stroke="#000"
+     width="13"
+     height="17"
+     x="3.5"
+     y="1.5"
+     id="rect881" />
+</svg>


### PR DESCRIPTION
I've included ( for the moment ) three new icons in the icon directory:

- file-md.svg
- file-epub.svg
- file-txt.svg

Users writing GUIs for certain tasks my need these icons. 

Why did I make another text icon? The existing text icon may be needed for other functions on the UI and the developer may need a way to differentiate "text" from the mime type "txt", that's why.

Best regards
D.Sanchez