### PR TITLE
Sticky support multiple offset values

### DIFF
--- a/src/js/core/sticky.js
+++ b/src/js/core/sticky.js
@@ -9,7 +9,7 @@ export default {
     props: {
         top: null,
         bottom: Boolean,
-        offset: String,
+        offset: 'list',
         animation: String,
         clsActive: String,
         clsInactive: String,
@@ -39,7 +39,7 @@ export default {
     computed: {
 
         offset({offset}) {
-            return toPx(offset);
+            return offset.reduce((acc, val) => acc + toPx(val), 0);
         },
 
         selTarget({selTarget}, $el) {


### PR DESCRIPTION
`offset` component option can work like css `calc()`
Example: `uk-sticky="offset: 100vh, -200"`