### PR TITLE
Added placeholder to Prompt in modal.js | Added 'reject' to deferred to copy "confirm" modal behaviour. 

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -96,12 +96,12 @@ function install({modal}) {
         );
     };
 
-    modal.prompt = function (message, value, options) {
+    modal.prompt = function (message, value, placeholder, options) {
         return openDialog(
             ({labels}) => `<form class="uk-form-stacked">
                 <div class="uk-modal-body">
                     <label>${isString(message) ? message : html(message)}</label>
-                    <input class="uk-input" value="${value || ''}" autofocus>
+                    <input class="uk-input" value="${value || ''}" autofocus placeholder="${placeholder || ''}">
                 </div>
                 <div class="uk-modal-footer uk-text-right">
                     <button class="uk-button uk-button-default uk-modal-close" type="button">${labels.cancel}</button>
@@ -109,7 +109,7 @@ function install({modal}) {
                 </div>
             </form>`,
             options,
-            deferred => deferred.resolve(null),
+            deferred => deferred.reject(),
             dialog => $('input', dialog.$el).value
         );
     };


### PR DESCRIPTION
Hi... I know this PR will never be accepted... since the parameter order represents a breaking change...

But I'm submitting this PR as a way of asking for the placeholder to be placed in any future versions.

ALSO:

I've noticed that clicking "Cancel" on the prompt doesn't "reject" the same way cancel button on the "confirm" modal does.