### PR TITLE
fix: Fixed issue with missing parentheses causing 'argument must be a number' errors with less-loader 10.0.1

### DIFF
--- a/src/less/components/card.less
+++ b/src/less/components/card.less
@@ -32,16 +32,16 @@
 @card-body-padding-vertical-l:                 @global-medium-gutter;
 
 @card-header-padding-horizontal:               @global-gutter;
-@card-header-padding-vertical:                 round(@global-gutter / 2);
+@card-header-padding-vertical:                 round((@global-gutter / 2));
 
 @card-header-padding-horizontal-l:             @global-medium-gutter;
-@card-header-padding-vertical-l:               round(@global-medium-gutter / 2);
+@card-header-padding-vertical-l:               round((@global-medium-gutter / 2));
 
 @card-footer-padding-horizontal:               @global-gutter;
 @card-footer-padding-vertical:                 (@global-gutter / 2);
 
 @card-footer-padding-horizontal-l:             @global-medium-gutter;
-@card-footer-padding-vertical-l:               round(@global-medium-gutter / 2);
+@card-footer-padding-vertical-l:               round((@global-medium-gutter / 2));
 
 @card-title-font-size:                         @global-large-font-size;
 @card-title-line-height:                       1.4;
@@ -76,16 +76,16 @@
 @card-small-body-padding-horizontal:           @global-margin;
 @card-small-body-padding-vertical:             @global-margin;
 @card-small-header-padding-horizontal:         @global-margin;
-@card-small-header-padding-vertical:           round(@global-margin / 1.5);
+@card-small-header-padding-vertical:           round((@global-margin / 1.5));
 @card-small-footer-padding-horizontal:         @global-margin;
-@card-small-footer-padding-vertical:           round(@global-margin / 1.5);
+@card-small-footer-padding-vertical:           round((@global-margin / 1.5));
 
 @card-large-body-padding-horizontal-l:         @global-large-gutter;
 @card-large-body-padding-vertical-l:           @global-large-gutter;
 @card-large-header-padding-horizontal-l:       @global-large-gutter;
-@card-large-header-padding-vertical-l:         round(@global-large-gutter / 2);
+@card-large-header-padding-vertical-l:         round((@global-large-gutter / 2));
 @card-large-footer-padding-horizontal-l:       @global-large-gutter;
-@card-large-footer-padding-vertical-l:         round(@global-large-gutter / 2);
+@card-large-footer-padding-vertical-l:         round((@global-large-gutter / 2));
 
 
 /* ========================================================================

--- a/src/less/components/form.less
+++ b/src/less/components/form.less
@@ -38,7 +38,7 @@
 @form-height:                                   @global-control-height;
 @form-line-height:                              @form-height;
 @form-padding-horizontal:                       10px;
-@form-padding-vertical:                         round(@form-padding-horizontal * 0.6);
+@form-padding-vertical:                         round((@form-padding-horizontal * 0.6));
 
 @form-background:                               @global-muted-background;
 @form-color:                                    @global-color;
@@ -53,13 +53,13 @@
 
 @form-small-height:                             @global-control-small-height;
 @form-small-padding-horizontal:                 8px;
-@form-small-padding-vertical:                   round(@form-small-padding-horizontal * 0.6);
+@form-small-padding-vertical:                   round((@form-small-padding-horizontal * 0.6));
 @form-small-line-height:                        @form-small-height;
 @form-small-font-size:                          @global-small-font-size;
 
 @form-large-height:                             @global-control-large-height;
 @form-large-padding-horizontal:                 12px;
-@form-large-padding-vertical:                   round(@form-large-padding-horizontal * 0.6);
+@form-large-padding-vertical:                   round((@form-large-padding-horizontal * 0.6));
 @form-large-line-height:                        @form-large-height;
 @form-large-font-size:                          @global-medium-font-size;
 

--- a/src/less/components/spinner.less
+++ b/src/less/components/spinner.less
@@ -11,8 +11,8 @@
 
 @spinner-size:                                  30px;
 @spinner-stroke-width:                          1;
-@spinner-radius:                                floor((@spinner-size - @spinner-stroke-width) / 2); // Minus stroke width to prevent overflow clipping
-@spinner-circumference:                         round(2 * 3.141 * @spinner-radius);
+@spinner-radius:                                floor(((@spinner-size - @spinner-stroke-width) / 2)); // Minus stroke width to prevent overflow clipping
+@spinner-circumference:                         round((2 * 3.141 * @spinner-radius));
 @spinner-duration:                              1.4s;
 
 

--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -261,11 +261,11 @@
 
     .uk-table-responsive th:not(:first-child):not(.uk-table-link),
     .uk-table-responsive td:not(:first-child):not(.uk-table-link),
-    .uk-table-responsive .uk-table-link:not(:first-child) > a { padding-top: round(@table-cell-padding-vertical / 3) !important; }
+    .uk-table-responsive .uk-table-link:not(:first-child) > a { padding-top: round((@table-cell-padding-vertical / 3)) !important; }
 
     .uk-table-responsive th:not(:last-child):not(.uk-table-link),
     .uk-table-responsive td:not(:last-child):not(.uk-table-link),
-    .uk-table-responsive .uk-table-link:not(:last-child) > a { padding-bottom: round(@table-cell-padding-vertical / 3) !important; }
+    .uk-table-responsive .uk-table-link:not(:last-child) > a { padding-bottom: round((@table-cell-padding-vertical / 3)) !important; }
 
     .uk-table-justify.uk-table-responsive th,
     .uk-table-justify.uk-table-responsive td {


### PR DESCRIPTION
less-loader 10.0.1 seems to have a bug that causes round() and floor() functions to throw an error - this is likely due to the order than less-loader resolves arguments. Adding these parentheses has no impact on the functionality of UIKit and changes nothing other than making it compatible with less-loader 10.0.1