### PR TITLE
fix: drop components from breaking when toggled while open

### DIFF
--- a/src/js/core/drop.js
+++ b/src/js/core/drop.js
@@ -247,7 +247,7 @@ export default {
             self: true,
 
             handler(e, toggled) {
-                attr(this.targetEl, 'aria-expanded', toggled ? true : null);
+                attr(this.targetEl, 'aria-expanded', !!toggled);
 
                 if (!toggled) {
                     return;


### PR DESCRIPTION
This PR fixes: #4797 

It's a recent issue caused by 58f452ad4386bc852aa714700ddde339217eb535. which sometimes set aria-expanded to null. which breaks behaviour of toggling drop components (navbars, dropdown, drops ...etc).

I fixed it by ensuring aria-expanded are only set to be either true or false.

Note: I didn't compile uikit in the commit. you can test the fix after compilation.

- [Error demo link](https://codepen.io/fahmifitu/pen/xxQxYeM)
- [Fix demo link](https://stackblitz.com/edit/web-platform-cdycoy?file=index.html)