### PR TITLE
fix: use for of instead of for in to prevent accidental loop over prototype properties

### DIFF
--- a/src/js/core/accordion.js
+++ b/src/js/core/accordion.js
@@ -139,7 +139,7 @@ export default {
     update() {
         const activeItems = filter(this.items, `.${this.clsOpen}`);
 
-        for (const index in this.items) {
+        for (const index of this.items) {
             const toggle = this.toggles[index];
             const content = this.contents[index];
 


### PR DESCRIPTION
We recently updated uikit to v3.16.22 and encountered the following error:
> TypeError: Cannot add property id, object is not extensible

This is caused by the use of `for(... in ...)` in the update function of `accordion.js`. The problem is that some framework use prototype extension (like ember.js) which then results in the update function throwing an error while looping over prototype properties. 

I personally think if `this.items` is always an array there is no reason to use `for(... of ...)`. What do you think?

Related: [issue](https://github.com/emberjs/ember.js/issues/19289)