### PR TITLE
fix: test scrollParent width when preventing touchmove event

### DIFF
--- a/src/js/mixin/internal/scroll.js
+++ b/src/js/mixin/internal/scroll.js
@@ -11,9 +11,9 @@ export function preventBackgroundScroll(el) {
                 return;
             }
 
-            let { scrollHeight, clientHeight } = scrollParent(e.target);
+            let { scrollHeight, clientHeight, scrollWidth, clientWidth } = scrollParent(e.target);
 
-            if (clientHeight >= scrollHeight && e.cancelable) {
+            if (e.cancelable && clientHeight >= scrollHeight && clientWidth >= scrollWidth) {
                 e.preventDefault();
             }
         },


### PR DESCRIPTION
This PR addresses the issue with touch-based scrolling inside of a modal component outlined [here](https://github.com/uikit/uikit/issues/4957).

