### PR TITLE
Update navbar.less to clear PRIMARY modifier

### DIFF
--- a/src/less/components/navbar.less
+++ b/src/less/components/navbar.less
@@ -357,7 +357,7 @@
 /* Style modifiers
  ========================================================================== */
 
-.uk-navbar-primary {
+.uk-navbar-container.uk-navbar-primary {
     .hook-navbar-primary();
 }
 


### PR DESCRIPTION
Primary modifier doesn't work because of container background. We need to add ```.uk-navbar-container``` selector to refine modifier.
**Before changes:**
![image](https://github.com/uikit/uikit/assets/4967754/00aca0bf-addb-4904-a0f2-7ba4fcfa66f0)
**After changes:**
![image](https://github.com/uikit/uikit/assets/4967754/e39b290a-af4e-45b1-babe-45687ef83714)

Thank you
