### PR TITLE
fix: Quotation issue in modal prompt

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -126,7 +126,7 @@ function install({ modal }) {
             ({ i18n }) => `<form class="uk-form-stacked">
                 <div class="uk-modal-body">
                     <label>${isString(message) ? message : html(message)}</label>
-                    <input class="uk-input" value="${value || ''}" autofocus>
+                    <input class="uk-input" value="" autofocus>
                 </div>
                 <div class="uk-modal-footer uk-text-right">
                     <button class="uk-button uk-button-default uk-modal-close" type="button">${
@@ -142,6 +142,7 @@ function install({ modal }) {
 
         const { $el } = promise.dialog;
         const input = $('input', $el);
+        input.value = value || '';
         on($el, 'show', () => input.select());
 
         return promise;

--- a/tests/modal.html
+++ b/tests/modal.html
@@ -487,7 +487,7 @@
             on('#js-modal-prompt', 'click', async e => {
                 e.preventDefault();
                 e.target.blur();
-                const name = await modal.prompt('Name:', 'Your name');
+                const name = await modal.prompt('Name:', 'Your "name"');
                 console.log('Prompted:', name);
             });
 


### PR DESCRIPTION
Currently the value of `UIKit.modal.prompt` does not properly escape double quotation marks ("), resulting in any text behind the quotes overflowing into the modal's HTML.
 
For example: 
```
UIkit.modal.prompt("Name:", 'start "quote" end').then(function (name) {
  console.log("Prompted:", name);
});
```
![image](https://github.com/uikit/uikit/assets/6525296/09e74f05-be92-42f0-b9d7-efc70b0bf6db)

```
<div class="uk-modal-body">
 <label>Name:</label>
 <input class="uk-input" value="start " quote"="" end"="" autofocus="">
</div>
```
https://codepen.io/inventivetalent/pen/PogvrLX


This PR moves the [inline input value assignment](https://github.com/uikit/uikit/blob/main/src/js/core/modal.js#L129) to use the `input.value` setter instead.
