### PR TITLE
feat: password prompts

### DIFF
--- a/src/js/core/modal.js
+++ b/src/js/core/modal.js
@@ -125,7 +125,7 @@ function install({ modal }) {
             ({ i18n }) => `<form class="uk-form-stacked">
                 <div class="uk-modal-body">
                     <label>${isString(message) ? message : html(message)}</label>
-                    <input class="uk-input" autofocus>
+                    <input type="${options.password ? "password" : "text"}" class="uk-input" autofocus>
                 </div>
                 <div class="uk-modal-footer uk-text-right">
                     <button class="uk-button uk-button-default uk-modal-close" type="button">${


### PR DESCRIPTION
Very small change that allows

```javascript
UIkit.modal.prompt('Password:', '1234', {password: true})
```

 to show a prompt with a password input.