### PR TITLE
refactor: @import and global built-in functions

### DIFF
--- a/src/scss/components/_import.scss
+++ b/src/scss/components/_import.scss
@@ -1,96 +1,96 @@
 // Base
-@import "variables.scss";
-@import "mixin.scss";
-@import "base.scss";
+@use "variables.scss";
+@use "mixin.scss";
+@use "base.scss";
 
 // Elements
-@import "link.scss";
-@import "heading.scss";
-@import "divider.scss";
-@import "list.scss";
-@import "description-list.scss";
-@import "table.scss";
-@import "icon.scss";
-@import "form-range.scss";
-@import "form.scss"; // After: Icon, Form Range
-@import "button.scss";
-@import "progress.scss";
+@use "link.scss";
+@use "heading.scss";
+@use "divider.scss";
+@use "list.scss";
+@use "description-list.scss";
+@use "table.scss";
+@use "icon.scss";
+@use "form-range.scss";
+@use "form.scss"; // After: Icon, Form Range
+@use "button.scss";
+@use "progress.scss";
 
 // Layout
-@import "section.scss";
-@import "container.scss";
-@import "tile.scss";
-@import "card.scss";
+@use "section.scss";
+@use "container.scss";
+@use "tile.scss";
+@use "card.scss";
 
 // Common
-@import "close.scss"; // After: Icon
-@import "spinner.scss"; // After: Icon
-@import "totop.scss"; // After: Icon
-@import "marker.scss"; // After: Icon
-@import "alert.scss"; // After: Close
-@import "placeholder.scss";
-@import "badge.scss";
-@import "label.scss";
-@import "overlay.scss"; // After: Icon
-@import "article.scss";
-@import "comment.scss";
-@import "search.scss"; // After: Icon
+@use "close.scss"; // After: Icon
+@use "spinner.scss"; // After: Icon
+@use "totop.scss"; // After: Icon
+@use "marker.scss"; // After: Icon
+@use "alert.scss"; // After: Close
+@use "placeholder.scss";
+@use "badge.scss";
+@use "label.scss";
+@use "overlay.scss"; // After: Icon
+@use "article.scss";
+@use "comment.scss";
+@use "search.scss"; // After: Icon
 
 // JavaScript
-@import "accordion.scss";
-@import "drop.scss"; // After: Card
-@import "dropbar.scss";
-@import "dropnav.scss"; // After: Dropbar
-@import "modal.scss"; // After: Close
-@import "slideshow.scss";
-@import "slider.scss";
-@import "sticky.scss";
-@import "offcanvas.scss";
-@import "switcher.scss";
-@import "leader.scss";
-@import "notification.scss";
-@import "tooltip.scss";
-@import "sortable.scss";
-@import "countdown.scss";
+@use "accordion.scss";
+@use "drop.scss"; // After: Card
+@use "dropbar.scss";
+@use "dropnav.scss"; // After: Dropbar
+@use "modal.scss"; // After: Close
+@use "slideshow.scss";
+@use "slider.scss";
+@use "sticky.scss";
+@use "offcanvas.scss";
+@use "switcher.scss";
+@use "leader.scss";
+@use "notification.scss";
+@use "tooltip.scss";
+@use "sortable.scss";
+@use "countdown.scss";
 // Scrollspy
 // Toggle
 // Scroll
 
-@import "thumbnav.scss";
-@import "iconnav.scss";
+@use "thumbnav.scss";
+@use "iconnav.scss";
 
-@import "grid.scss"; // After: Thumbnav, Iconnav
+@use "grid.scss"; // After: Thumbnav, Iconnav
 
 // Navs
-@import "nav.scss";
-@import "navbar.scss"; // After: Card, Grid, Nav, Icon, Search
-@import "subnav.scss";
-@import "breadcrumb.scss";
-@import "pagination.scss";
-@import "tab.scss";
-@import "slidenav.scss"; // After: Icon
-@import "dotnav.scss";
-@import "dropdown.scss"; // After: Card, Nav
-@import "lightbox.scss"; // After: Close, Slidenav
+@use "nav.scss";
+@use "navbar.scss"; // After: Card, Grid, Nav, Icon, Search
+@use "subnav.scss";
+@use "breadcrumb.scss";
+@use "pagination.scss";
+@use "tab.scss";
+@use "slidenav.scss"; // After: Icon
+@use "dotnav.scss";
+@use "dropdown.scss"; // After: Card, Nav
+@use "lightbox.scss"; // After: Close, Slidenav
 
 // Utilities
-@import "animation.scss";
-@import "width.scss";
-@import "height.scss";
-@import "text.scss";
-@import "column.scss";
-@import "cover.scss";
-@import "background.scss";
-@import "align.scss";
-@import "svg.scss";
-@import "utility.scss";
-@import "flex.scss"; // After: Utility
-@import "margin.scss";
-@import "padding.scss";
-@import "position.scss";
-@import "transition.scss";
-@import "visibility.scss";
-@import "inverse.scss";
+@use "animation.scss";
+@use "width.scss";
+@use "height.scss";
+@use "text.scss";
+@use "column.scss";
+@use "cover.scss";
+@use "background.scss";
+@use "align.scss";
+@use "svg.scss";
+@use "utility.scss";
+@use "flex.scss"; // After: Utility
+@use "margin.scss";
+@use "padding.scss";
+@use "position.scss";
+@use "transition.scss";
+@use "visibility.scss";
+@use "inverse.scss";
 
 // Need to be loaded last
-@import "print.scss";
+@use "print.scss";

--- a/src/scss/components/accordion.scss
+++ b/src/scss/components/accordion.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Accordion
 // Description:     Component to create accordions
 //
@@ -25,7 +26,7 @@
 .uk-accordion {
     padding: 0;
     list-style: none;
-    @if(mixin-exists(hook-accordion)) {@include hook-accordion();}
+    @if(meta.mixin-exists(hook-accordion)) {@include hook-accordion();}
 }
 
 
@@ -33,7 +34,7 @@
  ========================================================================== */
 
 .uk-accordion > * {
-    @if(mixin-exists(hook-accordion-item)) {@include hook-accordion-item();}
+    @if(meta.mixin-exists(hook-accordion-item)) {@include hook-accordion-item();}
 }
 
 .uk-accordion > :nth-child(n+2) { margin-top: $accordion-item-margin-top; }
@@ -47,14 +48,14 @@
     font-size: $accordion-title-font-size;
     line-height: $accordion-title-line-height;
     color: $accordion-title-color;
-    @if(mixin-exists(hook-accordion-title)) {@include hook-accordion-title();}
+    @if(meta.mixin-exists(hook-accordion-title)) {@include hook-accordion-title();}
 }
 
 /* Hover */
 .uk-accordion-title:hover {
     color: $accordion-title-hover-color;
     text-decoration: none;
-    @if(mixin-exists(hook-accordion-title-hover)) {@include hook-accordion-title-hover();}
+    @if(meta.mixin-exists(hook-accordion-title-hover)) {@include hook-accordion-title-hover();}
 }
 
 
@@ -64,7 +65,7 @@
 .uk-accordion-content {
     display: flow-root;
     margin-top: $accordion-content-margin-top;
-    @if(mixin-exists(hook-accordion-content)) {@include hook-accordion-content();}
+    @if(meta.mixin-exists(hook-accordion-content)) {@include hook-accordion-content();}
 }
 
 /*
@@ -77,7 +78,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-accordion-misc)) {@include hook-accordion-misc();}
+@if(meta.mixin-exists(hook-accordion-misc)) {@include hook-accordion-misc();}
 
 // @mixin hook-accordion(){}
 // @mixin hook-accordion-item(){}

--- a/src/scss/components/alert.scss
+++ b/src/scss/components/alert.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Alert
 // Description:     Component to create alert messages
 //
@@ -33,7 +34,7 @@
     padding: $alert-padding $alert-padding-right $alert-padding $alert-padding;
     background: $alert-background;
     color: $alert-color;
-    @if(mixin-exists(hook-alert)) {@include hook-alert();}
+    @if(meta.mixin-exists(hook-alert)) {@include hook-alert();}
 }
 
 /* Add margin if adjacent element */
@@ -54,7 +55,7 @@
     position: absolute;
     top: $alert-close-top;
     right: $alert-close-right;
-    @if(mixin-exists(hook-alert-close)) {@include hook-alert-close();}
+    @if(meta.mixin-exists(hook-alert-close)) {@include hook-alert-close();}
 }
 
 /*
@@ -68,7 +69,7 @@
  */
 
 .uk-alert-close:hover {
-    @if(mixin-exists(hook-alert-close-hover)) {@include hook-alert-close-hover();}
+    @if(meta.mixin-exists(hook-alert-close-hover)) {@include hook-alert-close-hover();}
 }
 
 
@@ -82,7 +83,7 @@
 .uk-alert-primary {
     background: $alert-primary-background;
     color: $alert-primary-color;
-    @if(mixin-exists(hook-alert-primary)) {@include hook-alert-primary();}
+    @if(meta.mixin-exists(hook-alert-primary)) {@include hook-alert-primary();}
 }
 
 /*
@@ -92,7 +93,7 @@
 .uk-alert-success {
     background: $alert-success-background;
     color: $alert-success-color;
-    @if(mixin-exists(hook-alert-success)) {@include hook-alert-success();}
+    @if(meta.mixin-exists(hook-alert-success)) {@include hook-alert-success();}
 }
 
 /*
@@ -102,7 +103,7 @@
 .uk-alert-warning {
     background: $alert-warning-background;
     color: $alert-warning-color;
-    @if(mixin-exists(hook-alert-warning)) {@include hook-alert-warning();}
+    @if(meta.mixin-exists(hook-alert-warning)) {@include hook-alert-warning();}
 }
 
 /*
@@ -112,14 +113,14 @@
 .uk-alert-danger {
     background: $alert-danger-background;
     color: $alert-danger-color;
-    @if(mixin-exists(hook-alert-danger)) {@include hook-alert-danger();}
+    @if(meta.mixin-exists(hook-alert-danger)) {@include hook-alert-danger();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-alert-misc)) {@include hook-alert-misc();}
+@if(meta.mixin-exists(hook-alert-misc)) {@include hook-alert-misc();}
 
 // @mixin hook-alert(){}
 // @mixin hook-alert-close(){}

--- a/src/scss/components/align.scss
+++ b/src/scss/components/align.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Align
 // Description:     Utilities to align embedded content
 //
@@ -55,7 +58,7 @@
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-align-left\@s {
         margin-top: 0;
@@ -72,7 +75,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-align-left\@m {
         margin-top: 0;
@@ -89,7 +92,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-align-left\@l {
         margin-top: 0;
@@ -114,7 +117,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-align-left\@xl {
         margin-top: 0;
@@ -134,6 +137,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-align-misc)) {@include hook-align-misc();}
+@if(meta.mixin-exists(hook-align-misc)) {@include hook-align-misc();}
 
 // @mixin hook-align-misc(){}

--- a/src/scss/components/animation.scss
+++ b/src/scss/components/animation.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Animation
 // Description:     Utilities for keyframe animations
 //
@@ -271,6 +272,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-animation-misc)) {@include hook-animation-misc();}
+@if(meta.mixin-exists(hook-animation-misc)) {@include hook-animation-misc();}
 
 // @mixin hook-animation-misc(){}

--- a/src/scss/components/article.scss
+++ b/src/scss/components/article.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Article
 // Description:     Component to create articles
 //
@@ -22,7 +25,7 @@
 
 .uk-article {
     display: flow-root;
-    @if(mixin-exists(hook-article)) {@include hook-article();}
+    @if(meta.mixin-exists(hook-article)) {@include hook-article();}
 }
 
 /*
@@ -37,7 +40,7 @@
 
 .uk-article + .uk-article {
     margin-top: $article-margin-top;
-    @if(mixin-exists(hook-article-adjacent)) {@include hook-article-adjacent();}
+    @if(meta.mixin-exists(hook-article-adjacent)) {@include hook-article-adjacent();}
 }
 
 
@@ -47,11 +50,11 @@
 .uk-article-title {
     font-size: $article-title-font-size;
     line-height: $article-title-line-height;
-    @if(mixin-exists(hook-article-title)) {@include hook-article-title();}
+    @if(meta.mixin-exists(hook-article-title)) {@include hook-article-title();}
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-article-title { font-size: $article-title-font-size-m; }
 
@@ -65,14 +68,14 @@
     font-size: $article-meta-font-size;
     line-height: $article-meta-line-height;
     color: $article-meta-color;
-    @if(mixin-exists(hook-article-meta)) {@include hook-article-meta();}
+    @if(meta.mixin-exists(hook-article-meta)) {@include hook-article-meta();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-article-misc)) {@include hook-article-misc();}
+@if(meta.mixin-exists(hook-article-misc)) {@include hook-article-misc();}
 
 // @mixin hook-article(){}
 // @mixin hook-article-adjacent(){}

--- a/src/scss/components/background.scss
+++ b/src/scss/components/background.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Background
 // Description:     Utilities for backgrounds
 //
@@ -131,6 +132,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-background-misc)) {@include hook-background-misc();}
+@if(meta.mixin-exists(hook-background-misc)) {@include hook-background-misc();}
 
 // @mixin hook-background-misc(){}

--- a/src/scss/components/badge.scss
+++ b/src/scss/components/badge.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Badge
 // Description:     Component to create notification badges
 //
@@ -36,7 +37,7 @@
     justify-content: center;
     align-items: center;
     line-height: 0;
-    @if(mixin-exists(hook-badge)) {@include hook-badge();}
+    @if(meta.mixin-exists(hook-badge)) {@include hook-badge();}
 }
 
 /*
@@ -45,14 +46,14 @@
 
 .uk-badge:hover {
     text-decoration: none;
-    @if(mixin-exists(hook-badge-hover)) {@include hook-badge-hover();}
+    @if(meta.mixin-exists(hook-badge-hover)) {@include hook-badge-hover();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-badge-misc)) {@include hook-badge-misc();}
+@if(meta.mixin-exists(hook-badge-misc)) {@include hook-badge-misc();}
 
 // @mixin hook-badge(){}
 // @mixin hook-badge-hover(){}

--- a/src/scss/components/base.scss
+++ b/src/scss/components/base.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Base
 // Description:     Default values for HTML elements
 //
@@ -44,7 +48,7 @@ html {
     /* 3 */
     background: $base-body-background;
     color: $base-body-color;
-    @if(mixin-exists(hook-base-body)) {@include hook-base-body();}
+    @if(meta.mixin-exists(hook-base-body)) {@include hook-base-body();}
 }
 
 /*
@@ -66,7 +70,7 @@ a,
     color: $base-link-color;
     text-decoration: $base-link-text-decoration;
     cursor: pointer;
-    @if(mixin-exists(hook-base-link)) {@include hook-base-link();}
+    @if(meta.mixin-exists(hook-base-link)) {@include hook-base-link();}
 }
 
 a:hover,
@@ -74,7 +78,7 @@ a:hover,
 .uk-link-toggle:hover .uk-link {
     color: $base-link-hover-color;
     text-decoration: $base-link-hover-text-decoration;
-    @if(mixin-exists(hook-base-link-hover)) {@include hook-base-link-hover();}
+    @if(meta.mixin-exists(hook-base-link-hover)) {@include hook-base-link-hover();}
 }
 
 
@@ -116,7 +120,7 @@ strong { font-weight: $base-strong-font-weight; }
     /* 3 */
     color: $base-code-color;
     white-space: nowrap;
-    @if(mixin-exists(hook-base-code)) {@include hook-base-code();}
+    @if(meta.mixin-exists(hook-base-code)) {@include hook-base-code();}
 }
 
 /*
@@ -272,7 +276,7 @@ h6, .uk-h6,
     font-weight: $base-heading-font-weight;
     color: $base-heading-color;
     text-transform: $base-heading-text-transform;
-    @if(mixin-exists(hook-base-heading)) {@include hook-base-heading();}
+    @if(meta.mixin-exists(hook-base-heading)) {@include hook-base-heading();}
 }
 
 /* Add margin if adjacent element */
@@ -296,41 +300,41 @@ h6, .uk-h6,
 h1, .uk-h1 {
     font-size: $base-h1-font-size;
     line-height: $base-h1-line-height;
-    @if(mixin-exists(hook-base-h1)) {@include hook-base-h1();}
+    @if(meta.mixin-exists(hook-base-h1)) {@include hook-base-h1();}
 }
 
 h2, .uk-h2 {
     font-size: $base-h2-font-size;
     line-height: $base-h2-line-height;
-    @if(mixin-exists(hook-base-h2)) {@include hook-base-h2();}
+    @if(meta.mixin-exists(hook-base-h2)) {@include hook-base-h2();}
 }
 
 h3, .uk-h3 {
     font-size: $base-h3-font-size;
     line-height: $base-h3-line-height;
-    @if(mixin-exists(hook-base-h3)) {@include hook-base-h3();}
+    @if(meta.mixin-exists(hook-base-h3)) {@include hook-base-h3();}
 }
 
 h4, .uk-h4 {
     font-size: $base-h4-font-size;
     line-height: $base-h4-line-height;
-    @if(mixin-exists(hook-base-h4)) {@include hook-base-h4();}
+    @if(meta.mixin-exists(hook-base-h4)) {@include hook-base-h4();}
 }
 
 h5, .uk-h5 {
     font-size: $base-h5-font-size;
     line-height: $base-h5-line-height;
-    @if(mixin-exists(hook-base-h5)) {@include hook-base-h5();}
+    @if(meta.mixin-exists(hook-base-h5)) {@include hook-base-h5();}
 }
 
 h6, .uk-h6 {
     font-size: $base-h6-font-size;
     line-height: $base-h6-line-height;
-    @if(mixin-exists(hook-base-h6)) {@include hook-base-h6();}
+    @if(meta.mixin-exists(hook-base-h6)) {@include hook-base-h6();}
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     h1, .uk-h1 { font-size: $base-h1-font-size-m; }
     h2, .uk-h2 { font-size: $base-h2-font-size-m; }
@@ -379,7 +383,7 @@ hr, .uk-hr {
     margin: 0 0 $base-hr-margin-vertical 0;
     border: 0;
     border-top: $base-hr-border-width solid $base-hr-border;
-    @if(mixin-exists(hook-base-hr)) {@include hook-base-hr();}
+    @if(meta.mixin-exists(hook-base-hr)) {@include hook-base-hr();}
 }
 
 /* Add margin if adjacent element */
@@ -401,7 +405,7 @@ blockquote {
     font-size: $base-blockquote-font-size;
     line-height: $base-blockquote-line-height;
     font-style: $base-blockquote-font-style;
-    @if(mixin-exists(hook-base-blockquote)) {@include hook-base-blockquote();}
+    @if(meta.mixin-exists(hook-base-blockquote)) {@include hook-base-blockquote();}
 }
 
 /* Add margin if adjacent element */
@@ -417,7 +421,7 @@ blockquote footer {
     margin-top: $base-blockquote-footer-margin-top;
     font-size: $base-blockquote-footer-font-size;
     line-height: $base-blockquote-footer-line-height;
-    @if(mixin-exists(hook-base-blockquote-footer)) {@include hook-base-blockquote-footer();}
+    @if(meta.mixin-exists(hook-base-blockquote-footer)) {@include hook-base-blockquote-footer();}
 }
 
 
@@ -429,13 +433,13 @@ blockquote footer {
  */
 
 pre {
-    font: $base-pre-font-size unquote("/") $base-pre-line-height $base-pre-font-family;
+    font: $base-pre-font-size string.unquote("/") $base-pre-line-height $base-pre-font-family;
     color: $base-pre-color;
     -moz-tab-size: 4;
     tab-size: 4;
     /* 1 */
     overflow: auto;
-    @if(mixin-exists(hook-base-pre)) {@include hook-base-pre();}
+    @if(meta.mixin-exists(hook-base-pre)) {@include hook-base-pre();}
 }
 
 pre code { font-family: $base-pre-font-family; }
@@ -493,16 +497,16 @@ template { display: none; }
  */
 
 :root {
-    --uk-breakpoint-s: #{$breakpoint-small};
-    --uk-breakpoint-m: #{$breakpoint-medium};
-    --uk-breakpoint-l: #{$breakpoint-large};
-    --uk-breakpoint-xl: #{$breakpoint-xlarge};
+    --uk-breakpoint-s: #{variables.$breakpoint-small};
+    --uk-breakpoint-m: #{variables.$breakpoint-medium};
+    --uk-breakpoint-l: #{variables.$breakpoint-large};
+    --uk-breakpoint-xl: #{variables.$breakpoint-xlarge};
 }
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-base-misc)) {@include hook-base-misc();}
+@if(meta.mixin-exists(hook-base-misc)) {@include hook-base-misc();}
 
 // @mixin hook-base-body(){}
 // @mixin hook-base-link(){}

--- a/src/scss/components/breadcrumb.scss
+++ b/src/scss/components/breadcrumb.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Breadcrumb
 // Description:     Component to create a breadcrumb navigation
 //
@@ -29,7 +30,7 @@
     list-style: none;
     /* 2 */
     font-size: 0;
-    @if(mixin-exists(hook-breadcrumb)) {@include hook-breadcrumb();}
+    @if(meta.mixin-exists(hook-breadcrumb)) {@include hook-breadcrumb();}
 }
 
 /*
@@ -45,26 +46,26 @@
 .uk-breadcrumb > * > * {
     font-size: $breadcrumb-item-font-size;
     color: $breadcrumb-item-color;
-    @if(mixin-exists(hook-breadcrumb-item)) {@include hook-breadcrumb-item();}
+    @if(meta.mixin-exists(hook-breadcrumb-item)) {@include hook-breadcrumb-item();}
 }
 
 /* Hover */
 .uk-breadcrumb > * > :hover {
     color: $breadcrumb-item-hover-color;
     text-decoration: $breadcrumb-item-hover-text-decoration;
-    @if(mixin-exists(hook-breadcrumb-item-hover)) {@include hook-breadcrumb-item-hover();}
+    @if(meta.mixin-exists(hook-breadcrumb-item-hover)) {@include hook-breadcrumb-item-hover();}
 }
 
 /* Disabled */
 .uk-breadcrumb > .uk-disabled > * {
-    @if(mixin-exists(hook-breadcrumb-item-disabled)) {@include hook-breadcrumb-item-disabled();}
+    @if(meta.mixin-exists(hook-breadcrumb-item-disabled)) {@include hook-breadcrumb-item-disabled();}
 }
 
 /* Active */
 .uk-breadcrumb > :last-child > span,
 .uk-breadcrumb > :last-child > a:not([href]) {
     color: $breadcrumb-item-active-color;
-    @if(mixin-exists(hook-breadcrumb-item-active)) {@include hook-breadcrumb-item-active();}
+    @if(meta.mixin-exists(hook-breadcrumb-item-active)) {@include hook-breadcrumb-item-active();}
 }
 
 /*
@@ -82,14 +83,14 @@
     /* 2 */
     font-size: $breadcrumb-divider-font-size;
     color: $breadcrumb-divider-color;
-    @if(mixin-exists(hook-breadcrumb-divider)) {@include hook-breadcrumb-divider();}
+    @if(meta.mixin-exists(hook-breadcrumb-divider)) {@include hook-breadcrumb-divider();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-breadcrumb-misc)) {@include hook-breadcrumb-misc();}
+@if(meta.mixin-exists(hook-breadcrumb-misc)) {@include hook-breadcrumb-misc();}
 
 // @mixin hook-breadcrumb(){}
 // @mixin hook-breadcrumb-item(){}

--- a/src/scss/components/button.scss
+++ b/src/scss/components/button.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Button
 // Description:     Styles for buttons
 //
@@ -78,7 +79,7 @@
     text-align: center;
     /* 10 */
     text-decoration: none;
-    @if(mixin-exists(hook-button)) {@include hook-button();}
+    @if(meta.mixin-exists(hook-button)) {@include hook-button();}
 }
 
 .uk-button:not(:disabled) { cursor: pointer; }
@@ -96,13 +97,13 @@
 .uk-button:hover {
     /* 9 */
     text-decoration: none;
-    @if(mixin-exists(hook-button-hover)) {@include hook-button-hover();}
+    @if(meta.mixin-exists(hook-button-hover)) {@include hook-button-hover();}
 }
 
 /* OnClick + Active */
 .uk-button:active,
 .uk-button.uk-active {
-    @if(mixin-exists(hook-button-active)) {@include hook-button-active();}
+    @if(meta.mixin-exists(hook-button-active)) {@include hook-button-active();}
 }
 
 
@@ -116,14 +117,14 @@
 .uk-button-default {
     background-color: $button-default-background;
     color: $button-default-color;
-    @if(mixin-exists(hook-button-default)) {@include hook-button-default();}
+    @if(meta.mixin-exists(hook-button-default)) {@include hook-button-default();}
 }
 
 /* Hover */
 .uk-button-default:hover {
     background-color: $button-default-hover-background;
     color: $button-default-hover-color;
-    @if(mixin-exists(hook-button-default-hover)) {@include hook-button-default-hover();}
+    @if(meta.mixin-exists(hook-button-default-hover)) {@include hook-button-default-hover();}
 }
 
 /* OnClick + Active */
@@ -131,7 +132,7 @@
 .uk-button-default.uk-active {
     background-color: $button-default-active-background;
     color: $button-default-active-color;
-    @if(mixin-exists(hook-button-default-active)) {@include hook-button-default-active();}
+    @if(meta.mixin-exists(hook-button-default-active)) {@include hook-button-default-active();}
 }
 
 /*
@@ -141,14 +142,14 @@
 .uk-button-primary {
     background-color: $button-primary-background;
     color: $button-primary-color;
-    @if(mixin-exists(hook-button-primary)) {@include hook-button-primary();}
+    @if(meta.mixin-exists(hook-button-primary)) {@include hook-button-primary();}
 }
 
 /* Hover */
 .uk-button-primary:hover {
     background-color: $button-primary-hover-background;
     color: $button-primary-hover-color;
-    @if(mixin-exists(hook-button-primary-hover)) {@include hook-button-primary-hover();}
+    @if(meta.mixin-exists(hook-button-primary-hover)) {@include hook-button-primary-hover();}
 }
 
 /* OnClick + Active */
@@ -156,7 +157,7 @@
 .uk-button-primary.uk-active {
     background-color: $button-primary-active-background;
     color: $button-primary-active-color;
-    @if(mixin-exists(hook-button-primary-active)) {@include hook-button-primary-active();}
+    @if(meta.mixin-exists(hook-button-primary-active)) {@include hook-button-primary-active();}
 }
 
 /*
@@ -166,14 +167,14 @@
 .uk-button-secondary {
     background-color: $button-secondary-background;
     color: $button-secondary-color;
-    @if(mixin-exists(hook-button-secondary)) {@include hook-button-secondary();}
+    @if(meta.mixin-exists(hook-button-secondary)) {@include hook-button-secondary();}
 }
 
 /* Hover */
 .uk-button-secondary:hover {
     background-color: $button-secondary-hover-background;
     color: $button-secondary-hover-color;
-    @if(mixin-exists(hook-button-secondary-hover)) {@include hook-button-secondary-hover();}
+    @if(meta.mixin-exists(hook-button-secondary-hover)) {@include hook-button-secondary-hover();}
 }
 
 /* OnClick + Active */
@@ -181,7 +182,7 @@
 .uk-button-secondary.uk-active {
     background-color: $button-secondary-active-background;
     color: $button-secondary-active-color;
-    @if(mixin-exists(hook-button-secondary-active)) {@include hook-button-secondary-active();}
+    @if(meta.mixin-exists(hook-button-secondary-active)) {@include hook-button-secondary-active();}
 }
 
 /*
@@ -191,14 +192,14 @@
 .uk-button-danger {
     background-color: $button-danger-background;
     color: $button-danger-color;
-    @if(mixin-exists(hook-button-danger)) {@include hook-button-danger();}
+    @if(meta.mixin-exists(hook-button-danger)) {@include hook-button-danger();}
 }
 
 /* Hover */
 .uk-button-danger:hover {
     background-color: $button-danger-hover-background;
     color: $button-danger-hover-color;
-    @if(mixin-exists(hook-button-danger-hover)) {@include hook-button-danger-hover();}
+    @if(meta.mixin-exists(hook-button-danger-hover)) {@include hook-button-danger-hover();}
 }
 
 /* OnClick + Active */
@@ -206,7 +207,7 @@
 .uk-button-danger.uk-active {
     background-color: $button-danger-active-background;
     color: $button-danger-active-color;
-    @if(mixin-exists(hook-button-danger-active)) {@include hook-button-danger-active();}
+    @if(meta.mixin-exists(hook-button-danger-active)) {@include hook-button-danger-active();}
 }
 
 /*
@@ -220,7 +221,7 @@
 .uk-button-danger:disabled {
     background-color: $button-disabled-background;
     color: $button-disabled-color;
-    @if(mixin-exists(hook-button-disabled)) {@include hook-button-disabled();}
+    @if(meta.mixin-exists(hook-button-disabled)) {@include hook-button-disabled();}
 }
 
 
@@ -231,14 +232,14 @@
     padding: 0 $button-small-padding-horizontal;
     line-height: $button-small-line-height;
     font-size: $button-small-font-size;
-    @if(mixin-exists(hook-button-small)) {@include hook-button-small();}
+    @if(meta.mixin-exists(hook-button-small)) {@include hook-button-small();}
 }
 
 .uk-button-large {
     padding: 0 $button-large-padding-horizontal;
     line-height: $button-large-line-height;
     font-size: $button-large-font-size;
-    @if(mixin-exists(hook-button-large)) {@include hook-button-large();}
+    @if(meta.mixin-exists(hook-button-large)) {@include hook-button-large();}
 }
 
 
@@ -258,19 +259,19 @@
     background: none;
     /* 2 */
     color: $button-text-color;
-    @if(mixin-exists(hook-button-text)) {@include hook-button-text();}
+    @if(meta.mixin-exists(hook-button-text)) {@include hook-button-text();}
 }
 
 /* Hover */
 .uk-button-text:hover {
     color: $button-text-hover-color;
-    @if(mixin-exists(hook-button-text-hover)) {@include hook-button-text-hover();}
+    @if(meta.mixin-exists(hook-button-text-hover)) {@include hook-button-text-hover();}
 }
 
 /* Disabled */
 .uk-button-text:disabled {
     color: $button-text-disabled-color;
-    @if(mixin-exists(hook-button-text-disabled)) {@include hook-button-text-disabled();}
+    @if(meta.mixin-exists(hook-button-text-disabled)) {@include hook-button-text-disabled();}
 }
 
 /*
@@ -286,7 +287,7 @@
     background: none;
     /* 2 */
     color: $button-link-color;
-    @if(mixin-exists(hook-button-link)) {@include hook-button-link();}
+    @if(meta.mixin-exists(hook-button-link)) {@include hook-button-link();}
 }
 
 /* Hover */
@@ -324,7 +325,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-button-misc)) {@include hook-button-misc();}
+@if(meta.mixin-exists(hook-button-misc)) {@include hook-button-misc();}
 
 // @mixin hook-button(){}
 // @mixin hook-button-hover(){}

--- a/src/scss/components/card.scss
+++ b/src/scss/components/card.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Card
 // Description:     Component to create boxed content containers
 //
@@ -47,7 +50,7 @@
 .uk-card {
     position: relative;
     box-sizing: border-box;
-    @if(mixin-exists(hook-card)) {@include hook-card();}
+    @if(meta.mixin-exists(hook-card)) {@include hook-card();}
 }
 
 
@@ -57,23 +60,23 @@
 .uk-card-body {
     display: flow-root;
     padding: $card-body-padding-vertical $card-body-padding-horizontal;
-    @if(mixin-exists(hook-card-body)) {@include hook-card-body();}
+    @if(meta.mixin-exists(hook-card-body)) {@include hook-card-body();}
 }
 
 .uk-card-header {
     display: flow-root;
     padding: $card-header-padding-vertical $card-header-padding-horizontal;
-    @if(mixin-exists(hook-card-header)) {@include hook-card-header();}
+    @if(meta.mixin-exists(hook-card-header)) {@include hook-card-header();}
 }
 
 .uk-card-footer {
     display: flow-root;
     padding: $card-footer-padding-vertical $card-footer-padding-horizontal;
-    @if(mixin-exists(hook-card-footer)) {@include hook-card-footer();}
+    @if(meta.mixin-exists(hook-card-footer)) {@include hook-card-footer();}
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-card-body { padding: $card-body-padding-vertical-l $card-body-padding-horizontal-l; }
 
@@ -101,25 +104,25 @@
  */
 
 [class*="uk-card-media"] {
-    @if(mixin-exists(hook-card-media)) {@include hook-card-media();}
+    @if(meta.mixin-exists(hook-card-media)) {@include hook-card-media();}
 }
 
 .uk-card-media-top,
 .uk-grid-stack > .uk-card-media-left,
 .uk-grid-stack > .uk-card-media-right {
-    @if(mixin-exists(hook-card-media-top)) {@include hook-card-media-top();}
+    @if(meta.mixin-exists(hook-card-media-top)) {@include hook-card-media-top();}
 }
 
 .uk-card-media-bottom {
-    @if(mixin-exists(hook-card-media-bottom)) {@include hook-card-media-bottom();}
+    @if(meta.mixin-exists(hook-card-media-bottom)) {@include hook-card-media-bottom();}
 }
 
 :not(.uk-grid-stack) > .uk-card-media-left {
-    @if(mixin-exists(hook-card-media-left)) {@include hook-card-media-left();}
+    @if(meta.mixin-exists(hook-card-media-left)) {@include hook-card-media-left();}
 }
 
 :not(.uk-grid-stack) > .uk-card-media-right {
-    @if(mixin-exists(hook-card-media-right)) {@include hook-card-media-right();}
+    @if(meta.mixin-exists(hook-card-media-right)) {@include hook-card-media-right();}
 }
 
 
@@ -129,7 +132,7 @@
 .uk-card-title {
     font-size: $card-title-font-size;
     line-height: $card-title-line-height;
-    @if(mixin-exists(hook-card-title)) {@include hook-card-title();}
+    @if(meta.mixin-exists(hook-card-title)) {@include hook-card-title();}
 }
 
 
@@ -161,7 +164,7 @@
     justify-content: center;
     align-items: center;
     line-height: 0;
-    @if(mixin-exists(hook-card-badge)) {@include hook-card-badge();}
+    @if(meta.mixin-exists(hook-card-badge)) {@include hook-card-badge();}
 }
 
 /*
@@ -176,7 +179,7 @@
 
 .uk-card-hover:not(.uk-card-default):not(.uk-card-primary):not(.uk-card-secondary):hover {
     background-color: $card-hover-background;
-    @if(mixin-exists(hook-card-hover)) {@include hook-card-hover();}
+    @if(meta.mixin-exists(hook-card-hover)) {@include hook-card-hover();}
 }
 
 
@@ -192,25 +195,25 @@
     --uk-inverse: #{$card-default-color-mode};
     background-color: $card-default-background;
     color: $card-default-color;
-    @if(mixin-exists(hook-card-default)) {@include hook-card-default();}
+    @if(meta.mixin-exists(hook-card-default)) {@include hook-card-default();}
 }
 
 .uk-card-default .uk-card-title {
     color: $card-default-title-color;
-    @if(mixin-exists(hook-card-default-title)) {@include hook-card-default-title();}
+    @if(meta.mixin-exists(hook-card-default-title)) {@include hook-card-default-title();}
 }
 
 .uk-card-default.uk-card-hover:hover {
     background-color: $card-default-hover-background;
-    @if(mixin-exists(hook-card-default-hover)) {@include hook-card-default-hover();}
+    @if(meta.mixin-exists(hook-card-default-hover)) {@include hook-card-default-hover();}
 }
 
 .uk-card-default .uk-card-header {
-    @if(mixin-exists(hook-card-default-header)) {@include hook-card-default-header();}
+    @if(meta.mixin-exists(hook-card-default-header)) {@include hook-card-default-header();}
 }
 
 .uk-card-default .uk-card-footer {
-    @if(mixin-exists(hook-card-default-footer)) {@include hook-card-default-footer();}
+    @if(meta.mixin-exists(hook-card-default-footer)) {@include hook-card-default-footer();}
 }
 
 // Color Mode
@@ -227,17 +230,17 @@
     --uk-inverse: #{$card-primary-color-mode};
     background-color: $card-primary-background;
     color: $card-primary-color;
-    @if(mixin-exists(hook-card-primary)) {@include hook-card-primary();}
+    @if(meta.mixin-exists(hook-card-primary)) {@include hook-card-primary();}
 }
 
 .uk-card-primary .uk-card-title {
     color: $card-primary-title-color;
-    @if(mixin-exists(hook-card-primary-title)) {@include hook-card-primary-title();}
+    @if(meta.mixin-exists(hook-card-primary-title)) {@include hook-card-primary-title();}
 }
 
 .uk-card-primary.uk-card-hover:hover {
     background-color: $card-primary-hover-background;
-    @if(mixin-exists(hook-card-primary-hover)) {@include hook-card-primary-hover();}
+    @if(meta.mixin-exists(hook-card-primary-hover)) {@include hook-card-primary-hover();}
 }
 
 // Color Mode
@@ -254,17 +257,17 @@
     --uk-inverse: #{$card-secondary-color-mode};
     background-color: $card-secondary-background;
     color: $card-secondary-color;
-    @if(mixin-exists(hook-card-secondary)) {@include hook-card-secondary();}
+    @if(meta.mixin-exists(hook-card-secondary)) {@include hook-card-secondary();}
 }
 
 .uk-card-secondary .uk-card-title {
     color: $card-secondary-title-color;
-    @if(mixin-exists(hook-card-secondary-title)) {@include hook-card-secondary-title();}
+    @if(meta.mixin-exists(hook-card-secondary-title)) {@include hook-card-secondary-title();}
 }
 
 .uk-card-secondary.uk-card-hover:hover {
     background-color: $card-secondary-hover-background;
-    @if(mixin-exists(hook-card-secondary-hover)) {@include hook-card-secondary-hover();}
+    @if(meta.mixin-exists(hook-card-secondary-hover)) {@include hook-card-secondary-hover();}
 }
 
 // Color Mode
@@ -292,7 +295,7 @@
  */
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-card-large.uk-card-body,
     .uk-card-large .uk-card-body { padding: $card-large-body-padding-vertical-l $card-large-body-padding-horizontal-l; }
@@ -306,7 +309,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-card-misc)) {@include hook-card-misc();}
+@if(meta.mixin-exists(hook-card-misc)) {@include hook-card-misc();}
 
 // @mixin hook-card(){}
 // @mixin hook-card-body(){}

--- a/src/scss/components/close.scss
+++ b/src/scss/components/close.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Close
 // Description:     Component to create a close button
 //
@@ -21,20 +22,20 @@
 
 .uk-close {
     color: $close-color;
-    @if(mixin-exists(hook-close)) {@include hook-close();}
+    @if(meta.mixin-exists(hook-close)) {@include hook-close();}
 }
 
 /* Hover */
 .uk-close:hover {
     color: $close-hover-color;
-    @if(mixin-exists(hook-close-hover)) {@include hook-close-hover();}
+    @if(meta.mixin-exists(hook-close-hover)) {@include hook-close-hover();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-close-misc)) {@include hook-close-misc();}
+@if(meta.mixin-exists(hook-close-misc)) {@include hook-close-misc();}
 
 // @mixin hook-close(){}
 // @mixin hook-close-hover(){}

--- a/src/scss/components/column.scss
+++ b/src/scss/components/column.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Column
 // Description:     Utilities for text columns
 //
@@ -23,7 +26,7 @@
 [class*="uk-column-"] { column-gap: $column-gutter; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     [class*="uk-column-"] { column-gap: $column-gutter-l; }
 
@@ -50,7 +53,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-column-divider {
         column-gap: ($column-gutter-l * 2);
@@ -69,7 +72,7 @@
 .uk-column-1-6 { column-count: 6; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-column-1-2\@s { column-count: 2; }
     .uk-column-1-3\@s { column-count: 3; }
@@ -80,7 +83,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-column-1-2\@m { column-count: 2; }
     .uk-column-1-3\@m { column-count: 3; }
@@ -91,7 +94,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-column-1-2\@l { column-count: 2; }
     .uk-column-1-3\@l { column-count: 3; }
@@ -102,7 +105,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-column-1-2\@xl { column-count: 2; }
     .uk-column-1-3\@xl { column-count: 3; }
@@ -122,7 +125,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-column-misc)) {@include hook-column-misc();}
+@if(meta.mixin-exists(hook-column-misc)) {@include hook-column-misc();}
 
 // @mixin hook-column-misc(){}
 

--- a/src/scss/components/comment.scss
+++ b/src/scss/components/comment.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Comment
 // Description:     Component to create nested comments
 //
@@ -28,7 +31,7 @@
  ========================================================================== */
 
 .uk-comment {
-    @if(mixin-exists(hook-comment)) {@include hook-comment();}
+    @if(meta.mixin-exists(hook-comment)) {@include hook-comment();}
 }
 
 
@@ -39,13 +42,13 @@
     display: flow-root;
     overflow-wrap: break-word;
     word-wrap: break-word;
-    @if(mixin-exists(hook-comment-body)) {@include hook-comment-body();}
+    @if(meta.mixin-exists(hook-comment-body)) {@include hook-comment-body();}
 }
 
 .uk-comment-header {
     display: flow-root;
     margin-bottom: $comment-header-margin-bottom;
-    @if(mixin-exists(hook-comment-header)) {@include hook-comment-header();}
+    @if(meta.mixin-exists(hook-comment-header)) {@include hook-comment-header();}
 }
 
 /*
@@ -62,7 +65,7 @@
 .uk-comment-title {
     font-size: $comment-title-font-size;
     line-height: $comment-title-line-height;
-    @if(mixin-exists(hook-comment-title)) {@include hook-comment-title();}
+    @if(meta.mixin-exists(hook-comment-title)) {@include hook-comment-title();}
 }
 
 
@@ -73,7 +76,7 @@
     font-size: $comment-meta-font-size;
     line-height: $comment-meta-line-height;
     color: $comment-meta-color;
-    @if(mixin-exists(hook-comment-meta)) {@include hook-comment-meta();}
+    @if(meta.mixin-exists(hook-comment-meta)) {@include hook-comment-meta();}
 }
 
 
@@ -81,7 +84,7 @@
  ========================================================================== */
 
 .uk-comment-avatar {
-    @if(mixin-exists(hook-comment-avatar)) {@include hook-comment-avatar();}
+    @if(meta.mixin-exists(hook-comment-avatar)) {@include hook-comment-avatar();}
 }
 
 
@@ -96,7 +99,7 @@
 /* Adjacent siblings */
 .uk-comment-list > :nth-child(n+2) {
     margin-top: $comment-list-margin-top;
-    @if(mixin-exists(hook-comment-list-adjacent)) {@include hook-comment-list-adjacent();}
+    @if(meta.mixin-exists(hook-comment-list-adjacent)) {@include hook-comment-list-adjacent();}
 }
 
 /*
@@ -108,11 +111,11 @@
     margin: $comment-list-margin-top 0 0 0;
     padding-left: $comment-list-padding-left;
     list-style: none;
-    @if(mixin-exists(hook-comment-list-sub)) {@include hook-comment-list-sub();}
+    @if(meta.mixin-exists(hook-comment-list-sub)) {@include hook-comment-list-sub();}
 }
 
 /* Tablet and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-comment-list .uk-comment ~ ul { padding-left: $comment-list-padding-left-m; }
 
@@ -121,7 +124,7 @@
 /* Adjacent siblings */
 .uk-comment-list .uk-comment ~ ul > :nth-child(n+2) {
     margin-top: $comment-list-margin-top;
-    @if(mixin-exists(hook-comment-list-sub-adjacent)) {@include hook-comment-list-sub-adjacent();}
+    @if(meta.mixin-exists(hook-comment-list-sub-adjacent)) {@include hook-comment-list-sub-adjacent();}
 }
 
 
@@ -129,14 +132,14 @@
  ========================================================================== */
 
 .uk-comment-primary {
-    @if(mixin-exists(hook-comment-primary)) {@include hook-comment-primary();}
+    @if(meta.mixin-exists(hook-comment-primary)) {@include hook-comment-primary();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-comment-misc)) {@include hook-comment-misc();}
+@if(meta.mixin-exists(hook-comment-misc)) {@include hook-comment-misc();}
 
 // @mixin hook-comment(){}
 // @mixin hook-comment-body(){}

--- a/src/scss/components/container.scss
+++ b/src/scss/components/container.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Container
 // Description:     Component to align and center your site and grid content
 //
@@ -41,7 +45,7 @@
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-container {
         padding-left: $container-padding-horizontal-s;
@@ -51,7 +55,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-container {
         padding-left: $container-padding-horizontal-m;
@@ -101,33 +105,33 @@
 .uk-container-expand-right { margin-right: 0; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-container-expand-left.uk-container-xsmall,
-    .uk-container-expand-right.uk-container-xsmall { max-width: unquote('calc(50% + (#{$container-xsmall-max-width} / 2) - #{$container-padding-horizontal-s})'); }
+    .uk-container-expand-right.uk-container-xsmall { max-width: string.unquote('calc(50% + (#{$container-xsmall-max-width} / 2) - #{$container-padding-horizontal-s})'); }
 
     .uk-container-expand-left.uk-container-small,
-    .uk-container-expand-right.uk-container-small { max-width: unquote('calc(50% + (#{$container-small-max-width} / 2) - #{$container-padding-horizontal-s})'); }
+    .uk-container-expand-right.uk-container-small { max-width: string.unquote('calc(50% + (#{$container-small-max-width} / 2) - #{$container-padding-horizontal-s})'); }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-container-expand-left,
-    .uk-container-expand-right { max-width: unquote('calc(50% + (#{$container-max-width} / 2) - #{$container-padding-horizontal-m})'); }
+    .uk-container-expand-right { max-width: string.unquote('calc(50% + (#{$container-max-width} / 2) - #{$container-padding-horizontal-m})'); }
 
     .uk-container-expand-left.uk-container-xsmall,
-    .uk-container-expand-right.uk-container-xsmall { max-width: unquote('calc(50% + (#{$container-xsmall-max-width} / 2) - #{$container-padding-horizontal-m})'); }
+    .uk-container-expand-right.uk-container-xsmall { max-width: string.unquote('calc(50% + (#{$container-xsmall-max-width} / 2) - #{$container-padding-horizontal-m})'); }
 
     .uk-container-expand-left.uk-container-small,
-    .uk-container-expand-right.uk-container-small { max-width: unquote('calc(50% + (#{$container-small-max-width} / 2) - #{$container-padding-horizontal-m})'); }
+    .uk-container-expand-right.uk-container-small { max-width: string.unquote('calc(50% + (#{$container-small-max-width} / 2) - #{$container-padding-horizontal-m})'); }
 
     .uk-container-expand-left.uk-container-large,
-    .uk-container-expand-right.uk-container-large { max-width: unquote('calc(50% + (#{$container-large-max-width} / 2) - #{$container-padding-horizontal-m})'); }
+    .uk-container-expand-right.uk-container-large { max-width: string.unquote('calc(50% + (#{$container-large-max-width} / 2) - #{$container-padding-horizontal-m})'); }
 
     .uk-container-expand-left.uk-container-xlarge,
-    .uk-container-expand-right.uk-container-xlarge { max-width: unquote('calc(50% + (#{$container-xlarge-max-width} / 2) - #{$container-padding-horizontal-m})'); }
+    .uk-container-expand-right.uk-container-xlarge { max-width: string.unquote('calc(50% + (#{$container-xlarge-max-width} / 2) - #{$container-padding-horizontal-m})'); }
 
 }
 
@@ -141,16 +145,16 @@
  */
 
 .uk-container-item-padding-remove-left,
-.uk-container-item-padding-remove-right { width: unquote('calc(100% + #{$container-padding-horizontal})'); }
+.uk-container-item-padding-remove-right { width: string.unquote('calc(100% + #{$container-padding-horizontal})'); }
 
 .uk-container-item-padding-remove-left { margin-left: (-$container-padding-horizontal); }
 .uk-container-item-padding-remove-right { margin-right: (-$container-padding-horizontal); }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-container-item-padding-remove-left,
-    .uk-container-item-padding-remove-right { width: unquote('calc(100% + #{$container-padding-horizontal-s})'); }
+    .uk-container-item-padding-remove-right { width: string.unquote('calc(100% + #{$container-padding-horizontal-s})'); }
 
     .uk-container-item-padding-remove-left { margin-left: (-$container-padding-horizontal-s); }
     .uk-container-item-padding-remove-right { margin-right: (-$container-padding-horizontal-s); }
@@ -158,10 +162,10 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-container-item-padding-remove-left,
-    .uk-container-item-padding-remove-right { width: unquote('calc(100% + #{$container-padding-horizontal-m})'); }
+    .uk-container-item-padding-remove-right { width: string.unquote('calc(100% + #{$container-padding-horizontal-m})'); }
 
     .uk-container-item-padding-remove-left { margin-left: (-$container-padding-horizontal-m); }
     .uk-container-item-padding-remove-right { margin-right: (-$container-padding-horizontal-m); }
@@ -172,6 +176,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-container-misc)) {@include hook-container-misc();}
+@if(meta.mixin-exists(hook-container-misc)) {@include hook-container-misc();}
 
 // @mixin hook-container-misc(){}

--- a/src/scss/components/countdown.scss
+++ b/src/scss/components/countdown.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Countdown
 // Description:     Component to create countdown timers
 //
@@ -27,7 +30,7 @@ $countdown-separator-font-size-m:                3rem !default; // 48px
  ========================================================================== */
 
 .uk-countdown {
-    @if(mixin-exists(hook-countdown)) {@include hook-countdown();}
+    @if(meta.mixin-exists(hook-countdown)) {@include hook-countdown();}
 }
 
 
@@ -36,7 +39,7 @@ $countdown-separator-font-size-m:                3rem !default; // 48px
 
 .uk-countdown-number,
 .uk-countdown-separator {
-    @if(mixin-exists(hook-countdown-item)) {@include hook-countdown-item();}
+    @if(meta.mixin-exists(hook-countdown-item)) {@include hook-countdown-item();}
 }
 
 
@@ -55,18 +58,18 @@ $countdown-separator-font-size-m:                3rem !default; // 48px
     /* 2 */
     font-size: $countdown-number-font-size;
     line-height: $countdown-number-line-height;
-    @if(mixin-exists(hook-countdown-number)) {@include hook-countdown-number();}
+    @if(meta.mixin-exists(hook-countdown-number)) {@include hook-countdown-number();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-countdown-number { font-size: $countdown-number-font-size-s; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-countdown-number { font-size: $countdown-number-font-size-m; }
 
@@ -79,18 +82,18 @@ $countdown-separator-font-size-m:                3rem !default; // 48px
 .uk-countdown-separator {
     font-size: $countdown-separator-font-size;
     line-height: $countdown-separator-line-height;
-    @if(mixin-exists(hook-countdown-separator)) {@include hook-countdown-separator();}
+    @if(meta.mixin-exists(hook-countdown-separator)) {@include hook-countdown-separator();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-countdown-separator { font-size: $countdown-separator-font-size-s; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-countdown-separator { font-size: $countdown-separator-font-size-m; }
 
@@ -101,14 +104,14 @@ $countdown-separator-font-size-m:                3rem !default; // 48px
  ========================================================================== */
 
 .uk-countdown-label {
-    @if(mixin-exists(hook-countdown-label)) {@include hook-countdown-label();}
+    @if(meta.mixin-exists(hook-countdown-label)) {@include hook-countdown-label();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-countdown-misc)) {@include hook-countdown-misc();}
+@if(meta.mixin-exists(hook-countdown-misc)) {@include hook-countdown-misc();}
 
 // @mixin hook-countdown(){}
 // @mixin hook-countdown-item(){}

--- a/src/scss/components/cover.scss
+++ b/src/scss/components/cover.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Cover
 // Description:     Utilities to let embedded content cover their container in a centered position
 //
@@ -71,6 +72,6 @@ iframe[data-uk-cover] { pointer-events: none; }
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-cover-misc)) {@include hook-cover-misc();}
+@if(meta.mixin-exists(hook-cover-misc)) {@include hook-cover-misc();}
 
 // @mixin hook-cover-misc(){}

--- a/src/scss/components/description-list.scss
+++ b/src/scss/components/description-list.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Description list
 // Description:     Styles for description lists
 //
@@ -24,7 +25,7 @@
 
 .uk-description-list > dt {
     color: $description-list-term-color;
-    @if(mixin-exists(hook-description-list-term)) {@include hook-description-list-term();}
+    @if(meta.mixin-exists(hook-description-list-term)) {@include hook-description-list-term();}
 }
 
 .uk-description-list > dt:nth-child(n+2) {
@@ -36,7 +37,7 @@
  */
 
 .uk-description-list > dd {
-    @if(mixin-exists(hook-description-list-description)) {@include hook-description-list-description();}
+    @if(meta.mixin-exists(hook-description-list-description)) {@include hook-description-list-description();}
 }
 
 
@@ -51,14 +52,14 @@
     margin-top: $description-list-divider-term-margin-top;
     padding-top: $description-list-divider-term-margin-top;
     border-top: $description-list-divider-term-border-width solid $description-list-divider-term-border;
-    @if(mixin-exists(hook-description-list-divider-term)) {@include hook-description-list-divider-term();}
+    @if(meta.mixin-exists(hook-description-list-divider-term)) {@include hook-description-list-divider-term();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-description-list-misc)) {@include hook-description-list-misc();}
+@if(meta.mixin-exists(hook-description-list-misc)) {@include hook-description-list-misc();}
 
 // @mixin hook-description-list-term(){}
 // @mixin hook-description-list-description(){}

--- a/src/scss/components/divider.scss
+++ b/src/scss/components/divider.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "mixin";
+
 // Name:            Divider
 // Description:     Styles for dividers
 //
@@ -43,10 +47,10 @@
 .uk-divider-icon {
     position: relative;
     height: $divider-icon-height;
-    @include svg-fill($internal-divider-icon-image, "#000", $divider-icon-color);
+    @include mixin.svg-fill($internal-divider-icon-image, "#000", $divider-icon-color);
     background-repeat: no-repeat;
     background-position: 50% 50%;
-    @if(mixin-exists(hook-divider-icon)) {@include hook-divider-icon();}
+    @if(meta.mixin-exists(hook-divider-icon)) {@include hook-divider-icon();}
 }
 
 .uk-divider-icon::before,
@@ -54,21 +58,21 @@
     content: "";
     position: absolute;
     top: $divider-icon-line-top;
-    max-width: unquote('calc(50% - (#{$divider-icon-width} / 2))');
+    max-width: string.unquote('calc(50% - (#{$divider-icon-width} / 2))');
     border-bottom: $divider-icon-line-border-width solid $divider-icon-line-border;
-    @if(mixin-exists(hook-divider-icon-line)) {@include hook-divider-icon-line();}
+    @if(meta.mixin-exists(hook-divider-icon-line)) {@include hook-divider-icon-line();}
 }
 
 .uk-divider-icon::before {
-    right: unquote('calc(50% + (#{$divider-icon-width} / 2))');
+    right: string.unquote('calc(50% + (#{$divider-icon-width} / 2))');
     width: $divider-icon-line-width;
-    @if(mixin-exists(hook-divider-icon-line-left)) {@include hook-divider-icon-line-left();}
+    @if(meta.mixin-exists(hook-divider-icon-line-left)) {@include hook-divider-icon-line-left();}
 }
 
 .uk-divider-icon::after {
-    left: unquote('calc(50% + (#{$divider-icon-width} / 2))');
+    left: string.unquote('calc(50% + (#{$divider-icon-width} / 2))');
     width: $divider-icon-line-width;
-    @if(mixin-exists(hook-divider-icon-line-right)) {@include hook-divider-icon-line-right();}
+    @if(meta.mixin-exists(hook-divider-icon-line-right)) {@include hook-divider-icon-line-right();}
 }
 
 
@@ -91,7 +95,7 @@
     max-width: 100%;
     border-top: $divider-small-border-width solid $divider-small-border;
     vertical-align: top;
-    @if(mixin-exists(hook-divider-small)) {@include hook-divider-small();}
+    @if(meta.mixin-exists(hook-divider-small)) {@include hook-divider-small();}
 }
 
 
@@ -104,14 +108,14 @@
     margin-left: auto;
     margin-right: auto;
     border-left: $divider-vertical-border-width solid $divider-vertical-border;
-    @if(mixin-exists(hook-divider-vertical)) {@include hook-divider-vertical();}
+    @if(meta.mixin-exists(hook-divider-vertical)) {@include hook-divider-vertical();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-divider-misc)) {@include hook-divider-misc();}
+@if(meta.mixin-exists(hook-divider-misc)) {@include hook-divider-misc();}
 
 // @mixin hook-divider-icon(){}
 // @mixin hook-divider-icon-line(){}

--- a/src/scss/components/dotnav.scss
+++ b/src/scss/components/dotnav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Dotnav
 // Description:     Component to create dot navigations
 //
@@ -37,7 +38,7 @@
     list-style: none;
     /* 3 */
     margin-left: (-$dotnav-margin-horizontal);
-    @if(mixin-exists(hook-dotnav)) {@include hook-dotnav();}
+    @if(meta.mixin-exists(hook-dotnav)) {@include hook-dotnav();}
 }
 
 /*
@@ -72,25 +73,25 @@
     text-indent: 100%;
     overflow: hidden;
     white-space: nowrap;
-    @if(mixin-exists(hook-dotnav-item)) {@include hook-dotnav-item();}
+    @if(meta.mixin-exists(hook-dotnav-item)) {@include hook-dotnav-item();}
 }
 
 /* Hover */
 .uk-dotnav > * > :hover {
     background-color: $dotnav-item-hover-background;
-    @if(mixin-exists(hook-dotnav-item-hover)) {@include hook-dotnav-item-hover();}
+    @if(meta.mixin-exists(hook-dotnav-item-hover)) {@include hook-dotnav-item-hover();}
 }
 
 /* OnClick */
 .uk-dotnav > * > :active {
     background-color: $dotnav-item-onclick-background;
-    @if(mixin-exists(hook-dotnav-item-onclick)) {@include hook-dotnav-item-onclick();}
+    @if(meta.mixin-exists(hook-dotnav-item-onclick)) {@include hook-dotnav-item-onclick();}
 }
 
 /* Active */
 .uk-dotnav > .uk-active > * {
     background-color: $dotnav-item-active-background;
-    @if(mixin-exists(hook-dotnav-item-active)) {@include hook-dotnav-item-active();}
+    @if(meta.mixin-exists(hook-dotnav-item-active)) {@include hook-dotnav-item-active();}
 }
 
 
@@ -120,7 +121,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-dotnav-misc)) {@include hook-dotnav-misc();}
+@if(meta.mixin-exists(hook-dotnav-misc)) {@include hook-dotnav-misc();}
 
 // @mixin hook-dotnav(){}
 // @mixin hook-dotnav-item(){}

--- a/src/scss/components/drop.scss
+++ b/src/scss/components/drop.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Drop
 // Description:     Component to position any element next to any other element.
 //
@@ -68,6 +69,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-drop-misc)) {@include hook-drop-misc();}
+@if(meta.mixin-exists(hook-drop-misc)) {@include hook-drop-misc();}
 
 // @mixin hook-drop-misc(){}

--- a/src/scss/components/dropbar.scss
+++ b/src/scss/components/dropbar.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Dropbar
 // Description:     Component to create a dropbar based on Drop component
 //
@@ -39,7 +42,7 @@
     padding: $dropbar-padding-top $dropbar-padding-horizontal $dropbar-padding-bottom $dropbar-padding-horizontal;
     background: $dropbar-background;
     color: $dropbar-color;
-    @if(mixin-exists(hook-dropbar)) {@include hook-dropbar();}
+    @if(meta.mixin-exists(hook-dropbar)) {@include hook-dropbar();}
 }
 
 /*
@@ -49,7 +52,7 @@
 .uk-dropbar > :last-child { margin-bottom: 0; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-dropbar {
         padding-left: $dropbar-padding-horizontal-s;
@@ -59,7 +62,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-dropbar {
         padding-left: $dropbar-padding-horizontal-m;
@@ -92,26 +95,26 @@
  ========================================================================== */
 
 .uk-dropbar-top {
-    @if(mixin-exists(hook-dropbar-top)) {@include hook-dropbar-top();}
+    @if(meta.mixin-exists(hook-dropbar-top)) {@include hook-dropbar-top();}
 }
 
 .uk-dropbar-bottom {
-    @if(mixin-exists(hook-dropbar-bottom)) {@include hook-dropbar-bottom();}
+    @if(meta.mixin-exists(hook-dropbar-bottom)) {@include hook-dropbar-bottom();}
 }
 
 .uk-dropbar-left {
-    @if(mixin-exists(hook-dropbar-left)) {@include hook-dropbar-left();}
+    @if(meta.mixin-exists(hook-dropbar-left)) {@include hook-dropbar-left();}
 }
 
 .uk-dropbar-right {
-    @if(mixin-exists(hook-dropbar-right)) {@include hook-dropbar-right();}
+    @if(meta.mixin-exists(hook-dropbar-right)) {@include hook-dropbar-right();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-dropbar-misc)) {@include hook-dropbar-misc();}
+@if(meta.mixin-exists(hook-dropbar-misc)) {@include hook-dropbar-misc();}
 
 // @mixin hook-dropbar(){}
 // @mixin hook-dropbar-top(){}

--- a/src/scss/components/dropdown.scss
+++ b/src/scss/components/dropdown.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Dropdown
 // Description:     Component to create a dropdown based on Drop component
 //
@@ -44,7 +47,7 @@
     padding: $dropdown-padding;
     background: $dropdown-background;
     color: $dropdown-color;
-    @if(mixin-exists(hook-dropdown)) {@include hook-dropdown();}
+    @if(meta.mixin-exists(hook-dropdown)) {@include hook-dropdown();}
 }
 
 /*
@@ -88,18 +91,18 @@
     /* 3 */
     padding: $dropdown-dropbar-padding-top 0 $dropdown-dropbar-padding-bottom 0;
     --uk-position-viewport-offset: #{$dropdown-dropbar-viewport-margin};
-    @if(mixin-exists(hook-dropdown-dropbar)) {@include hook-dropdown-dropbar();}
+    @if(meta.mixin-exists(hook-dropdown-dropbar)) {@include hook-dropdown-dropbar();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-dropdown-dropbar { --uk-position-viewport-offset: #{$dropdown-dropbar-viewport-margin-s}; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-dropdown-dropbar { --uk-position-viewport-offset: #{$dropdown-dropbar-viewport-margin-m}; }
 
@@ -108,7 +111,7 @@
 .uk-dropdown-dropbar-large {
     padding-top: $dropdown-dropbar-large-padding-top;
     padding-bottom: $dropdown-dropbar-large-padding-bottom;
-    @if(mixin-exists(hook-dropdown-dropbar-large)) {@include hook-dropdown-dropbar-large();}
+    @if(meta.mixin-exists(hook-dropdown-dropbar-large)) {@include hook-dropdown-dropbar-large();}
 }
 
 
@@ -117,7 +120,7 @@
  ========================================================================== */
 
 .uk-dropdown-nav {
-    @if(mixin-exists(hook-dropdown-nav)) {@include hook-dropdown-nav();}
+    @if(meta.mixin-exists(hook-dropdown-nav)) {@include hook-dropdown-nav();}
 }
 
 /*
@@ -126,14 +129,14 @@
 
 .uk-dropdown-nav > li > a {
     color: $dropdown-nav-item-color;
-    @if(mixin-exists(hook-dropdown-nav-item)) {@include hook-dropdown-nav-item();}
+    @if(meta.mixin-exists(hook-dropdown-nav-item)) {@include hook-dropdown-nav-item();}
 }
 
 /* Hover + Active */
 .uk-dropdown-nav > li > a:hover,
 .uk-dropdown-nav > li.uk-active > a {
     color: $dropdown-nav-item-hover-color;
-    @if(mixin-exists(hook-dropdown-nav-item-hover)) {@include hook-dropdown-nav-item-hover();}
+    @if(meta.mixin-exists(hook-dropdown-nav-item-hover)) {@include hook-dropdown-nav-item-hover();}
 }
 
 /*
@@ -142,7 +145,7 @@
 
 .uk-dropdown-nav .uk-nav-subtitle {
     font-size: $dropdown-nav-subtitle-font-size;
-    @if(mixin-exists(hook-dropdown-nav-subtitle)) {@include hook-dropdown-nav-subtitle();}
+    @if(meta.mixin-exists(hook-dropdown-nav-subtitle)) {@include hook-dropdown-nav-subtitle();}
 }
 
 /*
@@ -151,7 +154,7 @@
 
 .uk-dropdown-nav .uk-nav-header {
     color: $dropdown-nav-header-color;
-    @if(mixin-exists(hook-dropdown-nav-header)) {@include hook-dropdown-nav-header();}
+    @if(meta.mixin-exists(hook-dropdown-nav-header)) {@include hook-dropdown-nav-header();}
 }
 
 /*
@@ -160,7 +163,7 @@
 
 .uk-dropdown-nav .uk-nav-divider {
     border-top: $dropdown-nav-divider-border-width solid $dropdown-nav-divider-border;
-    @if(mixin-exists(hook-dropdown-nav-divider)) {@include hook-dropdown-nav-divider();}
+    @if(meta.mixin-exists(hook-dropdown-nav-divider)) {@include hook-dropdown-nav-divider();}
 }
 
 /*
@@ -176,7 +179,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-dropdown-misc)) {@include hook-dropdown-misc();}
+@if(meta.mixin-exists(hook-dropdown-misc)) {@include hook-dropdown-misc();}
 
 // @mixin hook-dropdown(){}
 // @mixin hook-dropdown-dropbar(){}

--- a/src/scss/components/dropnav.scss
+++ b/src/scss/components/dropnav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Dropnav
 // Description:     Component to create dropdown/dropbar menus based on Drop component
 //
@@ -37,6 +38,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-dropnav-misc)) {@include hook-dropnav-misc();}
+@if(meta.mixin-exists(hook-dropnav-misc)) {@include hook-dropnav-misc();}
 
 // @mixin hook-dropnav-misc(){}

--- a/src/scss/components/flex.scss
+++ b/src/scss/components/flex.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Flex
 // Description:     Utilities for layouts based on flexbox
 //
@@ -30,7 +33,7 @@
 .uk-flex-around { justify-content: space-around; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-flex-left\@s { justify-content: flex-start; }
     .uk-flex-center\@s { justify-content: center; }
@@ -41,7 +44,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-flex-left\@m { justify-content: flex-start; }
     .uk-flex-center\@m { justify-content: center; }
@@ -52,7 +55,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-flex-left\@l { justify-content: flex-start; }
     .uk-flex-center\@l { justify-content: center; }
@@ -63,7 +66,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-flex-left\@xl { justify-content: flex-start; }
     .uk-flex-center\@xl { justify-content: center; }
@@ -85,7 +88,7 @@
 .uk-flex-bottom { align-items: flex-end; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-flex-stretch\@s { align-items: stretch; }
     .uk-flex-top\@s { align-items: flex-start; }
@@ -95,7 +98,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-flex-stretch\@m { align-items: stretch; }
     .uk-flex-top\@m { align-items: flex-start; }
@@ -105,7 +108,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-flex-stretch\@l { align-items: stretch; }
     .uk-flex-top\@l { align-items: flex-start; }
@@ -115,7 +118,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-flex-stretch\@xl { align-items: stretch; }
     .uk-flex-top\@xl { align-items: flex-start; }
@@ -135,7 +138,7 @@
 .uk-flex-column-reverse { flex-direction: column-reverse; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-flex-row\@s { flex-direction: row; }
     .uk-flex-column\@s { flex-direction: column; }
@@ -143,7 +146,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-flex-row\@m { flex-direction: row; }
     .uk-flex-column\@m { flex-direction: column; }
@@ -151,7 +154,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-flex-row\@l { flex-direction: row; }
     .uk-flex-column\@l { flex-direction: column; }
@@ -159,7 +162,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-flex-row\@xl { flex-direction: row; }
     .uk-flex-column\@xl { flex-direction: column; }
@@ -200,7 +203,7 @@
 .uk-flex-last { order: 99;}
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-flex-first\@s { order: -1; }
     .uk-flex-last\@s { order: 99; }
@@ -208,7 +211,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-flex-first\@m { order: -1; }
     .uk-flex-last\@m { order: 99; }
@@ -216,7 +219,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-flex-first\@l { order: -1; }
     .uk-flex-last\@l { order: 99; }
@@ -224,7 +227,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-flex-first\@xl { order: -1; }
     .uk-flex-last\@xl { order: 99; }
@@ -264,7 +267,7 @@
 .uk-flex-1 { flex: 1; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-flex-initial\@s { flex: initial; }
     .uk-flex-none\@s { flex: none; }
@@ -273,7 +276,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-flex-initial\@m { flex: initial; }
     .uk-flex-none\@m { flex: none; }
@@ -282,7 +285,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-flex-initial\@l { flex: initial; }
     .uk-flex-none\@l { flex: none; }
@@ -291,7 +294,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-flex-initial\@xl { flex: initial; }
     .uk-flex-none\@xl { flex: none; }
@@ -303,6 +306,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-flex-misc)) {@include hook-flex-misc();}
+@if(meta.mixin-exists(hook-flex-misc)) {@include hook-flex-misc();}
 
 // @mixin hook-flex-misc(){}

--- a/src/scss/components/form-range.scss
+++ b/src/scss/components/form-range.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+@use "sass:meta";
 // Name:            Form Range
 // Description:     Styles for the range input type
 //
@@ -41,7 +43,7 @@
     width: 100%;
     /* 7 */
     background: transparent;
-    @if(mixin-exists(hook-form-range)) {@include hook-form-range();}
+    @if(meta.mixin-exists(hook-form-range)) {@include hook-form-range();}
 }
 
 /* Focus */
@@ -65,26 +67,26 @@
 .uk-range::-webkit-slider-runnable-track {
     height: $form-range-track-height;
     background: $form-range-track-background;
-    @if(mixin-exists(hook-form-range-track)) {@include hook-form-range-track();}
+    @if(meta.mixin-exists(hook-form-range-track)) {@include hook-form-range-track();}
 }
 
 .uk-range:focus::-webkit-slider-runnable-track,
 /* 1 */
 .uk-range:active::-webkit-slider-runnable-track {
     background: $form-range-track-focus-background;
-    @if(mixin-exists(hook-form-range-track-focus)) {@include hook-form-range-track-focus();}
+    @if(meta.mixin-exists(hook-form-range-track-focus)) {@include hook-form-range-track-focus();}
 }
 
 /* Firefox */
 .uk-range::-moz-range-track {
     height: $form-range-track-height;
     background: $form-range-track-background;
-    @if(mixin-exists(hook-form-range-track)) {@include hook-form-range-track();}
+    @if(meta.mixin-exists(hook-form-range-track)) {@include hook-form-range-track();}
 }
 
 .uk-range:focus::-moz-range-track {
     background: $form-range-track-focus-background;
-    @if(mixin-exists(hook-form-range-track-focus)) {@include hook-form-range-track-focus();}
+    @if(meta.mixin-exists(hook-form-range-track-focus)) {@include hook-form-range-track-focus();}
 }
 
 /*
@@ -97,13 +99,13 @@
 .uk-range::-webkit-slider-thumb {
     /* 1 */
     -webkit-appearance: none;
-    margin-top: (floor(($form-range-thumb-height * 0.5)) * -1);
+    margin-top: (math.floor(($form-range-thumb-height * 0.5)) * -1);
     /* 2 */
     height: $form-range-thumb-height;
     width: $form-range-thumb-width;
     border-radius: $form-range-thumb-border-radius;
     background: $form-range-thumb-background;
-    @if(mixin-exists(hook-form-range-thumb)) {@include hook-form-range-thumb();}
+    @if(meta.mixin-exists(hook-form-range-thumb)) {@include hook-form-range-thumb();}
 }
 
 /* Firefox */
@@ -113,17 +115,17 @@
     /* 2 */
     height: $form-range-thumb-height;
     width: $form-range-thumb-width;
-    margin-top: (floor(($form-range-thumb-height * 0.5)) * -1);
+    margin-top: (math.floor(($form-range-thumb-height * 0.5)) * -1);
     border-radius: $form-range-thumb-border-radius;
     background: $form-range-thumb-background;
-    @if(mixin-exists(hook-form-range-thumb)) {@include hook-form-range-thumb();}
+    @if(meta.mixin-exists(hook-form-range-thumb)) {@include hook-form-range-thumb();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-form-range-misc)) {@include hook-form-range-misc();}
+@if(meta.mixin-exists(hook-form-range-misc)) {@include hook-form-range-misc();}
 
 // @mixin hook-form-range(){}
 // @mixin hook-form-range-track(){}

--- a/src/scss/components/form.scss
+++ b/src/scss/components/form.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "mixin";
+@use "variables";
+
 // Name:            Form
 // Description:     Styles for forms
 //
@@ -206,7 +210,7 @@
     padding: 0 $form-padding-horizontal;
     background: $form-background;
     color: $form-color;
-    @if(mixin-exists(hook-form)) {@include hook-form();}
+    @if(meta.mixin-exists(hook-form)) {@include hook-form();}
 }
 
 /*
@@ -222,7 +226,7 @@
     vertical-align: middle;
     /* 1 */
     display: inline-block;
-    @if(mixin-exists(hook-form-single-line)) {@include hook-form-single-line();}
+    @if(meta.mixin-exists(hook-form-single-line)) {@include hook-form-single-line();}
 }
 
 /* 2 */
@@ -239,7 +243,7 @@
     padding-top: $form-padding-vertical;
     padding-bottom: $form-padding-vertical;
     vertical-align: top;
-    @if(mixin-exists(hook-form-multi-line)) {@include hook-form-multi-line();}
+    @if(meta.mixin-exists(hook-form-multi-line)) {@include hook-form-multi-line();}
 }
 
 .uk-select[multiple],
@@ -252,7 +256,7 @@
     outline: none;
     background-color: $form-focus-background;
     color: $form-focus-color;
-    @if(mixin-exists(hook-form-focus)) {@include hook-form-focus();}
+    @if(meta.mixin-exists(hook-form-focus)) {@include hook-form-focus();}
 }
 
 /* Disabled */
@@ -261,7 +265,7 @@
 .uk-textarea:disabled {
     background-color: $form-disabled-background;
     color: $form-disabled-color;
-    @if(mixin-exists(hook-form-disabled)) {@include hook-form-disabled();}
+    @if(meta.mixin-exists(hook-form-disabled)) {@include hook-form-disabled();}
 }
 
 /*
@@ -327,7 +331,7 @@ textarea.uk-form-large,
 .uk-form-danger,
 .uk-form-danger:focus {
     color: $form-danger-color;
-    @if(mixin-exists(hook-form-danger)) {@include hook-form-danger();}
+    @if(meta.mixin-exists(hook-form-danger)) {@include hook-form-danger();}
 }
 
 /*
@@ -337,7 +341,7 @@ textarea.uk-form-large,
 .uk-form-success,
 .uk-form-success:focus {
     color: $form-success-color;
-    @if(mixin-exists(hook-form-success)) {@include hook-form-success();}
+    @if(meta.mixin-exists(hook-form-success)) {@include hook-form-success();}
 }
 
 /*
@@ -346,11 +350,11 @@ textarea.uk-form-large,
 
 .uk-form-blank {
     background: none;
-    @if(mixin-exists(hook-form-blank)) {@include hook-form-blank();}
+    @if(meta.mixin-exists(hook-form-blank)) {@include hook-form-blank();}
 }
 
 .uk-form-blank:focus {
-    @if(mixin-exists(hook-form-blank-focus)) {@include hook-form-blank-focus();}
+    @if(meta.mixin-exists(hook-form-blank-focus)) {@include hook-form-blank-focus();}
 }
 
 
@@ -388,7 +392,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
     -moz-appearance: none;
     /* 2 */
     padding-right: $form-select-padding-right;
-    @include svg-fill($internal-form-select-image, "#000", $form-select-icon-color);
+    @include mixin.svg-fill($internal-form-select-image, "#000", $form-select-icon-color);
     background-repeat: no-repeat;
     background-position: 100% 50%;
 }
@@ -400,7 +404,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
  * Disabled
  */
 
-.uk-select:not([multiple]):not([size]):disabled { @include svg-fill($internal-form-select-image, "#000", $form-select-disabled-icon-color); }
+.uk-select:not([multiple]):not([size]):disabled { @include mixin.svg-fill($internal-form-select-image, "#000", $form-select-disabled-icon-color); }
 
 
 /* Datalist
@@ -417,7 +421,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 }
 
 .uk-input[list]:hover,
-.uk-input[list]:focus { @include svg-fill($internal-form-datalist-image, "#000", $form-datalist-icon-color); }
+.uk-input[list]:focus { @include mixin.svg-fill($internal-form-datalist-image, "#000", $form-datalist-icon-color); }
 
 /* 1 */
 .uk-input[list]::-webkit-calendar-picker-indicator { display: none !important; }
@@ -454,7 +458,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
     /* 6 */
     background-repeat: no-repeat;
     background-position: 50% 50%;
-    @if(mixin-exists(hook-form-radio)) {@include hook-form-radio();}
+    @if(meta.mixin-exists(hook-form-radio)) {@include hook-form-radio();}
 }
 
 .uk-radio { border-radius: 50%; }
@@ -464,7 +468,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 .uk-checkbox:focus {
     background-color: $form-radio-focus-background;
     outline: none;
-    @if(mixin-exists(hook-form-radio-focus)) {@include hook-form-radio-focus();}
+    @if(meta.mixin-exists(hook-form-radio-focus)) {@include hook-form-radio-focus();}
 }
 
 /*
@@ -475,7 +479,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 .uk-checkbox:checked,
 .uk-checkbox:indeterminate {
     background-color: $form-radio-checked-background;
-    @if(mixin-exists(hook-form-radio-checked)) {@include hook-form-radio-checked();}
+    @if(meta.mixin-exists(hook-form-radio-checked)) {@include hook-form-radio-checked();}
 }
 
 /* Focus */
@@ -483,16 +487,16 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 .uk-checkbox:checked:focus,
 .uk-checkbox:indeterminate:focus {
     background-color: $form-radio-checked-focus-background;
-    @if(mixin-exists(hook-form-radio-checked-focus)) {@include hook-form-radio-checked-focus();}
+    @if(meta.mixin-exists(hook-form-radio-checked-focus)) {@include hook-form-radio-checked-focus();}
 }
 
 /*
  * Icons
  */
 
-.uk-radio:checked { @include svg-fill($internal-form-radio-image, "#000", $form-radio-checked-icon-color); }
-.uk-checkbox:checked { @include svg-fill($internal-form-checkbox-image, "#000", $form-radio-checked-icon-color); }
-.uk-checkbox:indeterminate { @include svg-fill($internal-form-checkbox-indeterminate-image, "#000", $form-radio-checked-icon-color); }
+.uk-radio:checked { @include mixin.svg-fill($internal-form-radio-image, "#000", $form-radio-checked-icon-color); }
+.uk-checkbox:checked { @include mixin.svg-fill($internal-form-checkbox-image, "#000", $form-radio-checked-icon-color); }
+.uk-checkbox:indeterminate { @include mixin.svg-fill($internal-form-checkbox-indeterminate-image, "#000", $form-radio-checked-icon-color); }
 
 /*
  * Disabled
@@ -501,12 +505,12 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 .uk-radio:disabled,
 .uk-checkbox:disabled {
     background-color: $form-radio-disabled-background;
-    @if(mixin-exists(hook-form-radio-disabled)) {@include hook-form-radio-disabled();}
+    @if(meta.mixin-exists(hook-form-radio-disabled)) {@include hook-form-radio-disabled();}
 }
 
-.uk-radio:disabled:checked { @include svg-fill($internal-form-radio-image, "#000", $form-radio-disabled-icon-color); }
-.uk-checkbox:disabled:checked { @include svg-fill($internal-form-checkbox-image, "#000", $form-radio-disabled-icon-color); }
-.uk-checkbox:disabled:indeterminate { @include svg-fill($internal-form-checkbox-indeterminate-image, "#000", $form-radio-disabled-icon-color); }
+.uk-radio:disabled:checked { @include mixin.svg-fill($internal-form-radio-image, "#000", $form-radio-disabled-icon-color); }
+.uk-checkbox:disabled:checked { @include mixin.svg-fill($internal-form-checkbox-image, "#000", $form-radio-disabled-icon-color); }
+.uk-checkbox:disabled:indeterminate { @include mixin.svg-fill($internal-form-checkbox-indeterminate-image, "#000", $form-radio-disabled-icon-color); }
 
 
 /* Legend
@@ -530,7 +534,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
     /* 4 */
     font-size: $form-legend-font-size;
     line-height: $form-legend-line-height;
-    @if(mixin-exists(hook-form-legend)) {@include hook-form-legend();}
+    @if(meta.mixin-exists(hook-form-legend)) {@include hook-form-legend();}
 }
 
 
@@ -593,7 +597,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
  ========================================================================== */
 
 .uk-form-label {
-    @if(mixin-exists(hook-form-label)) {@include hook-form-label();}
+    @if(meta.mixin-exists(hook-form-label)) {@include hook-form-label();}
 }
 
 
@@ -607,7 +611,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 .uk-form-stacked .uk-form-label {
     display: block;
     margin-bottom: $form-stacked-margin-bottom;
-    @if(mixin-exists(hook-form-stacked-label)) {@include hook-form-stacked-label();}
+    @if(meta.mixin-exists(hook-form-stacked-label)) {@include hook-form-stacked-label();}
 }
 
 /*
@@ -621,19 +625,19 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
     .uk-form-horizontal .uk-form-label {
         display: block;
         margin-bottom: $form-stacked-margin-bottom;
-        @if(mixin-exists(hook-form-stacked-label)) {@include hook-form-stacked-label();}
+        @if(meta.mixin-exists(hook-form-stacked-label)) {@include hook-form-stacked-label();}
     }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-form-horizontal .uk-form-label {
         width: $form-horizontal-label-width;
         margin-top: $form-horizontal-label-margin-top;
         float: left;
-        @if(mixin-exists(hook-form-horizontal-label)) {@include hook-form-horizontal-label();}
+        @if(meta.mixin-exists(hook-form-horizontal-label)) {@include hook-form-horizontal-label();}
     }
 
     .uk-form-horizontal .uk-form-controls { margin-left: $form-horizontal-controls-margin-left; }
@@ -668,7 +672,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
     align-items: center;
     /* 4 */
     color: $form-icon-color;
-    @if(mixin-exists(hook-form-icon)) {@include hook-form-icon();}
+    @if(meta.mixin-exists(hook-form-icon)) {@include hook-form-icon();}
 }
 
 /*
@@ -704,7 +708,7 @@ select.uk-form-width-xsmall { width: ($form-width-xsmall + 25px); }
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-form-misc)) {@include hook-form-misc();}
+@if(meta.mixin-exists(hook-form-misc)) {@include hook-form-misc();}
 
 // @mixin hook-form(){}
 // @mixin hook-form-single-line(){}

--- a/src/scss/components/grid.scss
+++ b/src/scss/components/grid.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Grid
 // Description:     Component to create responsive, fluid and nestable grids
 //
@@ -83,7 +86,7 @@
 * + .uk-grid-margin { margin-top: $grid-gutter-vertical; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     /* Horizontal */
     .uk-grid { margin-left: (-$grid-gutter-horizontal-l); }
@@ -148,7 +151,7 @@
 * + .uk-grid-margin-large { margin-top: $grid-large-gutter-vertical; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     /* Horizontal */
     .uk-grid-large,
@@ -193,7 +196,7 @@
     top: 0;
     bottom: 0;
     border-left: $grid-divider-border-width solid $grid-divider-border;
-    @if(mixin-exists(hook-grid-divider-horizontal)) {@include hook-grid-divider-horizontal();}
+    @if(meta.mixin-exists(hook-grid-divider-horizontal)) {@include hook-grid-divider-horizontal();}
 }
 
 /* Vertical */
@@ -203,7 +206,7 @@
     left: 0;
     right: 0;
     border-top: $grid-divider-border-width solid $grid-divider-border;
-    @if(mixin-exists(hook-grid-divider-vertical)) {@include hook-grid-divider-vertical();}
+    @if(meta.mixin-exists(hook-grid-divider-vertical)) {@include hook-grid-divider-vertical();}
 }
 
 /*
@@ -225,7 +228,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     /* Horizontal */
     .uk-grid-divider { margin-left: -($grid-gutter-horizontal-l * 2); }
@@ -319,7 +322,7 @@
 .uk-grid-divider.uk-grid-column-large.uk-grid-stack > .uk-grid-margin::before { left: ($grid-large-gutter-horizontal * 2); }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     /* Horizontal */
     .uk-grid-divider.uk-grid-large,
@@ -375,7 +378,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-grid-misc)) {@include hook-grid-misc();}
+@if(meta.mixin-exists(hook-grid-misc)) {@include hook-grid-misc();}
 
 // @mixin hook-grid-divider-horizontal(){}
 // @mixin hook-grid-divider-vertical(){}

--- a/src/scss/components/heading.scss
+++ b/src/scss/components/heading.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Heading
 // Description:     Styles for headings
 //
@@ -45,41 +49,41 @@ $heading-3xlarge-font-size-l:                    15rem !default;                
 .uk-heading-small {
     font-size: $heading-small-font-size;
     line-height: $heading-small-line-height;
-    @if(mixin-exists(hook-heading-small)) {@include hook-heading-small();}
+    @if(meta.mixin-exists(hook-heading-small)) {@include hook-heading-small();}
 }
 
 .uk-heading-medium {
     font-size: $heading-medium-font-size;
     line-height: $heading-medium-line-height;
-    @if(mixin-exists(hook-heading-medium)) {@include hook-heading-medium();}
+    @if(meta.mixin-exists(hook-heading-medium)) {@include hook-heading-medium();}
 }
 
 .uk-heading-large {
     font-size: $heading-large-font-size;
     line-height: $heading-large-line-height;
-    @if(mixin-exists(hook-heading-large)) {@include hook-heading-large();}
+    @if(meta.mixin-exists(hook-heading-large)) {@include hook-heading-large();}
 }
 
 .uk-heading-xlarge {
     font-size: $heading-xlarge-font-size;
     line-height: $heading-xlarge-line-height;
-    @if(mixin-exists(hook-heading-xlarge)) {@include hook-heading-xlarge();}
+    @if(meta.mixin-exists(hook-heading-xlarge)) {@include hook-heading-xlarge();}
 }
 
 .uk-heading-2xlarge {
     font-size: $heading-2xlarge-font-size;
     line-height: $heading-2xlarge-line-height;
-    @if(mixin-exists(hook-heading-2xlarge)) {@include hook-heading-2xlarge();}
+    @if(meta.mixin-exists(hook-heading-2xlarge)) {@include hook-heading-2xlarge();}
 }
 
 .uk-heading-3xlarge {
     font-size: $heading-3xlarge-font-size;
     line-height: $heading-3xlarge-line-height;
-    @if(mixin-exists(hook-heading-3xlarge)) {@include hook-heading-3xlarge();}
+    @if(meta.mixin-exists(hook-heading-3xlarge)) {@include hook-heading-3xlarge();}
 }
 
 /* Tablet Landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-heading-small { font-size: $heading-small-font-size-m; }
     .uk-heading-medium { font-size: $heading-medium-font-size-m; }
@@ -91,7 +95,7 @@ $heading-3xlarge-font-size-l:                    15rem !default;                
 }
 
 /* Laptop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-heading-medium { font-size: $heading-medium-font-size-l; }
     .uk-heading-large { font-size: $heading-large-font-size-l; }
@@ -116,12 +120,12 @@ $heading-primary-font-size:                      $heading-primary-font-size-l * 
 .uk-heading-primary {
     font-size: $heading-primary-font-size;
     line-height: $heading-primary-line-height;
-    @if(mixin-exists(hook-heading-primary)) {@include hook-heading-primary();}
+    @if(meta.mixin-exists(hook-heading-primary)) {@include hook-heading-primary();}
 }
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     @if ($deprecated == true) {
 .uk-heading-primary { font-size: $heading-primary-font-size-m; }
@@ -130,7 +134,7 @@ $heading-primary-font-size:                      $heading-primary-font-size-l * 
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     @if ($deprecated == true) {
 .uk-heading-primary {
@@ -156,12 +160,12 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
 .uk-heading-hero {
     font-size: $heading-hero-font-size;
     line-height: $heading-hero-line-height;
-    @if(mixin-exists(hook-heading-hero)) {@include hook-heading-hero();}
+    @if(meta.mixin-exists(hook-heading-hero)) {@include hook-heading-hero();}
 }
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     @if ($deprecated == true) {
 .uk-heading-hero {
@@ -173,7 +177,7 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     @if ($deprecated == true) {
 .uk-heading-hero {
@@ -191,7 +195,7 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
 .uk-heading-divider {
     padding-bottom: $heading-divider-padding-bottom;
     border-bottom: $heading-divider-border-width solid $heading-divider-border;
-    @if(mixin-exists(hook-heading-divider)) {@include hook-heading-divider();}
+    @if(meta.mixin-exists(hook-heading-divider)) {@include hook-heading-divider();}
 }
 
 
@@ -218,7 +222,7 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
     height: $heading-bullet-height;
     margin-right: $heading-bullet-margin-right;
     border-left: $heading-bullet-border-width solid $heading-bullet-border;
-    @if(mixin-exists(hook-heading-bullet)) {@include hook-heading-bullet();}
+    @if(meta.mixin-exists(hook-heading-bullet)) {@include hook-heading-bullet();}
 }
 
 
@@ -251,12 +255,12 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
     content: "";
     /* 1 */
     position: absolute;
-    top: unquote('calc(#{$heading-line-top} - (#{$heading-line-height} / 2))');
+    top: string.unquote('calc(#{$heading-line-top} - (#{$heading-line-height} / 2))');
     /* 2 */
     width: $heading-line-width;
     /* 3 */
     border-bottom: $heading-line-border-width solid $heading-line-border;
-    @if(mixin-exists(hook-heading-line)) {@include hook-heading-line();}
+    @if(meta.mixin-exists(hook-heading-line)) {@include hook-heading-line();}
 }
 
 .uk-heading-line > ::before {
@@ -272,7 +276,7 @@ $heading-hero-font-size:                         $heading-hero-font-size-l * 0.5
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-heading-misc)) {@include hook-heading-misc();}
+@if(meta.mixin-exists(hook-heading-misc)) {@include hook-heading-misc();}
 
 // @mixin hook-heading-small(){}
 // @mixin hook-heading-medium(){}

--- a/src/scss/components/height.scss
+++ b/src/scss/components/height.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Height
 // Description:     Utilities for heights
 //
@@ -49,6 +50,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-height-misc)) {@include hook-height-misc();}
+@if(meta.mixin-exists(hook-height-misc)) {@include hook-height-misc();}
 
 // @mixin hook-height-misc(){}

--- a/src/scss/components/icon.scss
+++ b/src/scss/components/icon.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Icon
 // Description:     Component to create icons
 //
@@ -125,19 +126,19 @@ button.uk-icon:not(:disabled) { cursor: pointer; }
     color: $icon-link-color;
     /* 1 */
     text-decoration: none !important;
-    @if(mixin-exists(hook-icon-link)) {@include hook-icon-link();}
+    @if(meta.mixin-exists(hook-icon-link)) {@include hook-icon-link();}
 }
 
 .uk-icon-link:hover {
     color: $icon-link-hover-color;
-    @if(mixin-exists(hook-icon-link-hover)) {@include hook-icon-link-hover();}
+    @if(meta.mixin-exists(hook-icon-link-hover)) {@include hook-icon-link-hover();}
 }
 
 /* OnClick + Active */
 .uk-icon-link:active,
 .uk-active > .uk-icon-link {
     color: $icon-link-active-color;
-    @if(mixin-exists(hook-icon-link-active)) {@include hook-icon-link-active();}
+    @if(meta.mixin-exists(hook-icon-link-active)) {@include hook-icon-link-active();}
 }
 
 /*
@@ -157,14 +158,14 @@ button.uk-icon:not(:disabled) { cursor: pointer; }
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    @if(mixin-exists(hook-icon-button)) {@include hook-icon-button();}
+    @if(meta.mixin-exists(hook-icon-button)) {@include hook-icon-button();}
 }
 
 /* Hover */
 .uk-icon-button:hover {
     background-color: $icon-button-hover-background;
     color: $icon-button-hover-color;
-    @if(mixin-exists(hook-icon-button-hover)) {@include hook-icon-button-hover();}
+    @if(meta.mixin-exists(hook-icon-button-hover)) {@include hook-icon-button-hover();}
 }
 
 /* OnClick + Active */
@@ -172,14 +173,14 @@ button.uk-icon:not(:disabled) { cursor: pointer; }
 .uk-active > .uk-icon-button {
     background-color: $icon-button-active-background;
     color: $icon-button-active-color;
-    @if(mixin-exists(hook-icon-button-active)) {@include hook-icon-button-active();}
+    @if(meta.mixin-exists(hook-icon-button-active)) {@include hook-icon-button-active();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-icon-misc)) {@include hook-icon-misc();}
+@if(meta.mixin-exists(hook-icon-misc)) {@include hook-icon-misc();}
 
 // @mixin hook-icon-link(){}
 // @mixin hook-icon-link-hover(){}

--- a/src/scss/components/iconnav.scss
+++ b/src/scss/components/iconnav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Iconnav
 // Description:     Component to create icon navigations
 //
@@ -38,7 +39,7 @@
     list-style: none;
     /* 3 */
     margin-left: (-$iconnav-margin-horizontal);
-    @if(mixin-exists(hook-iconnav)) {@include hook-iconnav();}
+    @if(meta.mixin-exists(hook-iconnav)) {@include hook-iconnav();}
 }
 
 /*
@@ -76,19 +77,19 @@
     color: $iconnav-item-color;
     /* 5 */
     text-decoration: none;
-    @if(mixin-exists(hook-iconnav-item)) {@include hook-iconnav-item();}
+    @if(meta.mixin-exists(hook-iconnav-item)) {@include hook-iconnav-item();}
 }
 
 /* Hover */
 .uk-iconnav > * > a:hover {
     color: $iconnav-item-hover-color;
-    @if(mixin-exists(hook-iconnav-item-hover)) {@include hook-iconnav-item-hover();}
+    @if(meta.mixin-exists(hook-iconnav-item-hover)) {@include hook-iconnav-item-hover();}
 }
 
 /* Active */
 .uk-iconnav > .uk-active > a {
     color: $iconnav-item-active-color;
-    @if(mixin-exists(hook-iconnav-item-active)) {@include hook-iconnav-item-active();}
+    @if(meta.mixin-exists(hook-iconnav-item-active)) {@include hook-iconnav-item-active();}
 }
 
 
@@ -118,7 +119,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-iconnav-misc)) {@include hook-iconnav-misc();}
+@if(meta.mixin-exists(hook-iconnav-misc)) {@include hook-iconnav-misc();}
 
 // @mixin hook-iconnav(){}
 // @mixin hook-iconnav-item(){}

--- a/src/scss/components/inverse.scss
+++ b/src/scss/components/inverse.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Inverse
 // Description:     Inverse component style for light or dark backgrounds
 //
@@ -26,9 +27,9 @@
  * `uk-dark` is or dark colors on light backgrounds
  */
 
-@if ($inverse-global-color-mode == light) { .uk-light { @if (mixin-exists(hook-inverse)) {@include hook-inverse();}}}
+@if ($inverse-global-color-mode == light) { .uk-light { @if (meta.mixin-exists(hook-inverse)) {@include hook-inverse();}}}
 
-@if ($inverse-global-color-mode == dark) { .uk-dark { @if (mixin-exists(hook-inverse)) {@include hook-inverse();}}}
+@if ($inverse-global-color-mode == dark) { .uk-dark { @if (meta.mixin-exists(hook-inverse)) {@include hook-inverse();}}}
 
 /*
  * Pass dropbar behind color to JS

--- a/src/scss/components/label.scss
+++ b/src/scss/components/label.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Label
 // Description:     Component to indicate important notes
 //
@@ -29,7 +30,7 @@
     color: $label-color;
     vertical-align: middle;
     white-space: nowrap;
-    @if(mixin-exists(hook-label)) {@include hook-label();}
+    @if(meta.mixin-exists(hook-label)) {@include hook-label();}
 }
 
 
@@ -43,7 +44,7 @@
 .uk-label-success {
     background-color: $label-success-background;
     color: $label-success-color;
-    @if(mixin-exists(hook-label-success)) {@include hook-label-success();}
+    @if(meta.mixin-exists(hook-label-success)) {@include hook-label-success();}
 }
 
 /*
@@ -53,7 +54,7 @@
 .uk-label-warning {
     background-color: $label-warning-background;
     color: $label-warning-color;
-    @if(mixin-exists(hook-label-warning)) {@include hook-label-warning();}
+    @if(meta.mixin-exists(hook-label-warning)) {@include hook-label-warning();}
 }
 
 /*
@@ -63,14 +64,14 @@
 .uk-label-danger {
     background-color: $label-danger-background;
     color: $label-danger-color;
-    @if(mixin-exists(hook-label-danger)) {@include hook-label-danger();}
+    @if(meta.mixin-exists(hook-label-danger)) {@include hook-label-danger();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-label-misc)) {@include hook-label-misc();}
+@if(meta.mixin-exists(hook-label-misc)) {@include hook-label-misc();}
 
 // @mixin hook-label(){}
 // @mixin hook-label-success(){}

--- a/src/scss/components/leader.scss
+++ b/src/scss/components/leader.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Leader
 // Description:     Component to create dot leaders
 //
@@ -34,7 +35,7 @@
     content: attr(data-fill);
     /* 4 */
     white-space: nowrap;
-    @if(mixin-exists(hook-leader)) {@include hook-leader();}
+    @if(meta.mixin-exists(hook-leader)) {@include hook-leader();}
 }
 
 /*
@@ -53,7 +54,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-leader-misc)) {@include hook-leader-misc();}
+@if(meta.mixin-exists(hook-leader-misc)) {@include hook-leader-misc();}
 
 // @mixin hook-leader(){}
 // @mixin hook-leader-misc(){}

--- a/src/scss/components/lightbox.scss
+++ b/src/scss/components/lightbox.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Lightbox
 // Description:     Component to create an lightbox image gallery
 //
@@ -60,7 +61,7 @@
     transition: opacity 0.15s linear;
     /* 7 */
     touch-action: pinch-zoom;
-    @if(mixin-exists(hook-lightbox)) {@include hook-lightbox();}
+    @if(meta.mixin-exists(hook-lightbox)) {@include hook-lightbox();}
 }
 
 /*
@@ -128,7 +129,7 @@
     will-change: transform, opacity;
     /* 4 */
     overflow: auto;
-    @if(mixin-exists(hook-lightbox-item)) {@include hook-lightbox-item();}
+    @if(meta.mixin-exists(hook-lightbox-item)) {@include hook-lightbox-item();}
 }
 
 /* 2 */
@@ -171,7 +172,7 @@
     padding: $lightbox-caption-padding-vertical $lightbox-caption-padding-horizontal;
     background: $lightbox-caption-background;
     color: $lightbox-caption-color;
-    @if(mixin-exists(hook-lightbox-caption)) {@include hook-lightbox-caption();}
+    @if(meta.mixin-exists(hook-lightbox-caption)) {@include hook-lightbox-caption();}
 }
 
 .uk-lightbox-caption > * { color: $lightbox-caption-color; }
@@ -195,7 +196,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-lightbox-misc)) {@include hook-lightbox-misc();}
+@if(meta.mixin-exists(hook-lightbox-misc)) {@include hook-lightbox-misc();}
 
 // @mixin hook-lightbox(){}
 // @mixin hook-lightbox-item(){}

--- a/src/scss/components/link.scss
+++ b/src/scss/components/link.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Link
 // Description:     Styles for links
 //
@@ -30,14 +31,14 @@ a.uk-link-muted,
 .uk-link-muted a,
 .uk-link-toggle .uk-link-muted {
     color: $link-muted-color;
-    @if(mixin-exists(hook-link-muted)) {@include hook-link-muted();}
+    @if(meta.mixin-exists(hook-link-muted)) {@include hook-link-muted();}
 }
 
 a.uk-link-muted:hover,
 .uk-link-muted a:hover,
 .uk-link-toggle:hover .uk-link-muted {
     color: $link-muted-hover-color;
-    @if(mixin-exists(hook-link-muted-hover)) {@include hook-link-muted-hover();}
+    @if(meta.mixin-exists(hook-link-muted-hover)) {@include hook-link-muted-hover();}
 }
 
 
@@ -48,14 +49,14 @@ a.uk-link-text,
 .uk-link-text a,
 .uk-link-toggle .uk-link-text {
     color: inherit;
-    @if(mixin-exists(hook-link-text)) {@include hook-link-text();}
+    @if(meta.mixin-exists(hook-link-text)) {@include hook-link-text();}
 }
 
 a.uk-link-text:hover,
 .uk-link-text a:hover,
 .uk-link-toggle:hover .uk-link-text {
     color: $link-text-hover-color;
-    @if(mixin-exists(hook-link-text-hover)) {@include hook-link-text-hover();}
+    @if(meta.mixin-exists(hook-link-text-hover)) {@include hook-link-text-hover();}
 }
 
 
@@ -66,7 +67,7 @@ a.uk-link-heading,
 .uk-link-heading a,
 .uk-link-toggle .uk-link-heading {
     color: inherit;
-    @if(mixin-exists(hook-link-heading)) {@include hook-link-heading();}
+    @if(meta.mixin-exists(hook-link-heading)) {@include hook-link-heading();}
 }
 
 a.uk-link-heading:hover,
@@ -74,7 +75,7 @@ a.uk-link-heading:hover,
 .uk-link-toggle:hover .uk-link-heading {
     color: $link-heading-hover-color;
     text-decoration: $link-heading-hover-text-decoration;
-    @if(mixin-exists(hook-link-heading-hover)) {@include hook-link-heading-hover();}
+    @if(meta.mixin-exists(hook-link-heading-hover)) {@include hook-link-heading-hover();}
 }
 
 
@@ -89,7 +90,7 @@ a.uk-link-reset,
 .uk-link-reset a {
     color: inherit !important;
     text-decoration: none !important;
-    @if(mixin-exists(hook-link-reset)) {@include hook-link-reset();}
+    @if(meta.mixin-exists(hook-link-reset)) {@include hook-link-reset();}
 }
 
 
@@ -105,7 +106,7 @@ a.uk-link-reset,
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-link-misc)) {@include hook-link-misc();}
+@if(meta.mixin-exists(hook-link-misc)) {@include hook-link-misc();}
 
 // @mixin hook-link-muted(){}
 // @mixin hook-link-muted-hover(){}

--- a/src/scss/components/list.scss
+++ b/src/scss/components/list.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "mixin";
+@use "variables";
+
 // Name:            List
 // Description:     Styles for lists
 //
@@ -102,8 +106,8 @@
     top: 0;
     left: 0;
     width: $list-padding-left;
-    height: $global-line-height * 1em;
-    @include svg-fill($internal-list-bullet-image, "#000", $list-bullet-icon-color);
+    height: variables.$global-line-height * 1em;
+    @include mixin.svg-fill($internal-list-bullet-image, "#000", $list-bullet-icon-color);
     background-repeat: no-repeat;
     background-position: 50% 50%;
 }
@@ -120,7 +124,7 @@
     margin-top: $list-divider-margin-top;
     padding-top: $list-divider-margin-top;
     border-top: $list-divider-border-width solid $list-divider-border;
-    @if(mixin-exists(hook-list-divider)) {@include hook-list-divider();}
+    @if(meta.mixin-exists(hook-list-divider)) {@include hook-list-divider();}
 }
 
 /*
@@ -129,7 +133,7 @@
 
 .uk-list-striped > * {
     padding: $list-striped-padding-vertical $list-striped-padding-horizontal;
-    @if(mixin-exists(hook-list-striped)) {@include hook-list-striped();}
+    @if(meta.mixin-exists(hook-list-striped)) {@include hook-list-striped();}
 }
 
 .uk-list-striped > :nth-of-type(odd) { background: $list-striped-background; }
@@ -178,7 +182,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-list-misc)) {@include hook-list-misc();}
+@if(meta.mixin-exists(hook-list-misc)) {@include hook-list-misc();}
 
 // @mixin hook-list-divider(){}
 // @mixin hook-list-striped(){}

--- a/src/scss/components/margin.scss
+++ b/src/scss/components/margin.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Margin
 // Description:     Utilities for margins
 //
@@ -87,7 +90,7 @@
 .uk-margin-large-right { margin-right: $margin-large-margin !important; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-margin-large { margin-bottom: $margin-large-margin-l; }
     * + .uk-margin-large { margin-top: $margin-large-margin-l !important; }
@@ -112,7 +115,7 @@
 .uk-margin-xlarge-right { margin-right: $margin-xlarge-margin !important; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-margin-xlarge { margin-bottom: $margin-xlarge-margin-l; }
     * + .uk-margin-xlarge { margin-top: $margin-xlarge-margin-l !important; }
@@ -144,7 +147,7 @@
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-margin-auto\@s {
         margin-left: auto !important;
@@ -157,7 +160,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-margin-auto\@m {
         margin-left: auto !important;
@@ -170,7 +173,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-margin-auto\@l {
         margin-left: auto !important;
@@ -183,7 +186,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-margin-auto\@xl {
         margin-left: auto !important;
@@ -215,7 +218,7 @@
 .uk-margin-remove-last-child > :last-child { margin-bottom: 0 !important; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-margin-remove-left\@s { margin-left: 0 !important; }
     .uk-margin-remove-right\@s { margin-right: 0 !important; }
@@ -223,7 +226,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-margin-remove-left\@m { margin-left: 0 !important; }
     .uk-margin-remove-right\@m { margin-right: 0 !important; }
@@ -231,7 +234,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-margin-remove-left\@l { margin-left: 0 !important; }
     .uk-margin-remove-right\@l { margin-right: 0 !important; }
@@ -239,7 +242,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-margin-remove-left\@xl { margin-left: 0 !important; }
     .uk-margin-remove-right\@xl { margin-right: 0 !important; }
@@ -250,6 +253,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-margin-misc)) {@include hook-margin-misc();}
+@if(meta.mixin-exists(hook-margin-misc)) {@include hook-margin-misc();}
 
 // @mixin hook-margin-misc(){}

--- a/src/scss/components/marker.scss
+++ b/src/scss/components/marker.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Marker
 // Description:     Component to create a marker icon
 //
@@ -24,20 +25,20 @@
     padding: $marker-padding;
     background: $marker-background;
     color: $marker-color;
-    @if(mixin-exists(hook-marker)) {@include hook-marker();}
+    @if(meta.mixin-exists(hook-marker)) {@include hook-marker();}
 }
 
 /* Hover */
 .uk-marker:hover {
     color: $marker-hover-color;
-    @if(mixin-exists(hook-marker-hover)) {@include hook-marker-hover();}
+    @if(meta.mixin-exists(hook-marker-hover)) {@include hook-marker-hover();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-marker-misc)) {@include hook-marker-misc();}
+@if(meta.mixin-exists(hook-marker-misc)) {@include hook-marker-misc();}
 
 // @mixin hook-marker(){}
 // @mixin hook-marker-hover(){}

--- a/src/scss/components/mixin.scss
+++ b/src/scss/components/mixin.scss
@@ -1,3 +1,4 @@
+@use "sass:string";
 //
 // Component:       Mixin
 // Description:     Defines mixins which are used across all components
@@ -14,11 +15,11 @@
 /// @param {String} $replace ('') - New value
 /// @return {String} - Updated string
 @function str-replace($string, $search, $replace: '') {
-    $index: str-index($string, $search);
+    $index: string.index($string, $search);
 
     @if $index {
-        @return str-slice($string, 1, $index - 1) + $replace +
-            str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+        @return string.slice($string, 1, $index - 1) + $replace +
+            str-replace(string.slice($string, $index + string.length($search)), $search, $replace);
     }
 
     @return $string;
@@ -27,6 +28,6 @@
 @mixin svg-fill($src, $color-default, $color-new) {
     $replace-src: str-replace($src, $color-default, $color-new) !default;
     $replace-src: str-replace($replace-src, '#', '%23');
-    $replace-src: quote($replace-src);
+    $replace-src: string.quote($replace-src);
     background-image: url($replace-src);
 }

--- a/src/scss/components/modal.scss
+++ b/src/scss/components/modal.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Modal
 // Description:     Component to create modal dialogs
 //
@@ -69,18 +72,18 @@
     /* 6 */
     opacity: 0;
     transition: opacity 0.15s linear;
-    @if(mixin-exists(hook-modal)) {@include hook-modal();}
+    @if(meta.mixin-exists(hook-modal)) {@include hook-modal();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-modal { padding: $modal-padding-vertical-s $modal-padding-horizontal-s; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-modal {
         padding-left: $modal-padding-horizontal-m;
@@ -133,7 +136,7 @@
     transform: translateY(-100px);
     transition: 0.3s linear;
     transition-property: opacity, transform;
-    @if(mixin-exists(hook-modal-dialog)) {@include hook-modal-dialog();}
+    @if(meta.mixin-exists(hook-modal-dialog)) {@include hook-modal-dialog();}
 }
 
 /*
@@ -174,7 +177,7 @@
     width: 100%;
     max-width: 100%;
     transform: translateY(0);
-    @if(mixin-exists(hook-modal-full)) {@include hook-modal-full();}
+    @if(meta.mixin-exists(hook-modal-full)) {@include hook-modal-full();}
 }
 
 
@@ -184,25 +187,25 @@
 .uk-modal-body {
     display: flow-root;
     padding: $modal-body-padding-vertical $modal-body-padding-horizontal;
-    @if(mixin-exists(hook-modal-body)) {@include hook-modal-body();}
+    @if(meta.mixin-exists(hook-modal-body)) {@include hook-modal-body();}
 }
 
 .uk-modal-header {
     display: flow-root;
     padding: $modal-header-padding-vertical $modal-header-padding-horizontal;
     background: $modal-header-background;
-    @if(mixin-exists(hook-modal-header)) {@include hook-modal-header();}
+    @if(meta.mixin-exists(hook-modal-header)) {@include hook-modal-header();}
 }
 
 .uk-modal-footer {
     display: flow-root;
     padding: $modal-footer-padding-vertical $modal-footer-padding-horizontal;
     background: $modal-footer-background;
-    @if(mixin-exists(hook-modal-footer)) {@include hook-modal-footer();}
+    @if(meta.mixin-exists(hook-modal-footer)) {@include hook-modal-footer();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-modal-body { padding: $modal-body-padding-vertical-s $modal-body-padding-horizontal-s; }
     .uk-modal-header { padding: $modal-header-padding-vertical-s $modal-header-padding-horizontal-s; }
@@ -225,7 +228,7 @@
 .uk-modal-title {
     font-size: $modal-title-font-size;
     line-height: $modal-title-line-height;
-    @if(mixin-exists(hook-modal-title)) {@include hook-modal-title();}
+    @if(meta.mixin-exists(hook-modal-title)) {@include hook-modal-title();}
 }
 
 
@@ -239,7 +242,7 @@
     top: $modal-close-position;
     right: $modal-close-position;
     padding: $modal-close-padding;
-    @if(mixin-exists(hook-modal-close)) {@include hook-modal-close();}
+    @if(meta.mixin-exists(hook-modal-close)) {@include hook-modal-close();}
 }
 
 /*
@@ -253,7 +256,7 @@
  */
 
 [class*="uk-modal-close-"]:hover {
-    @if(mixin-exists(hook-modal-close-hover)) {@include hook-modal-close-hover();}
+    @if(meta.mixin-exists(hook-modal-close-hover)) {@include hook-modal-close-hover();}
 }
 
 /*
@@ -261,11 +264,11 @@
  */
 
 .uk-modal-close-default {
-    @if(mixin-exists(hook-modal-close-default)) {@include hook-modal-close-default();}
+    @if(meta.mixin-exists(hook-modal-close-default)) {@include hook-modal-close-default();}
 }
 
 .uk-modal-close-default:hover {
-    @if(mixin-exists(hook-modal-close-default-hover)) {@include hook-modal-close-default-hover();}
+    @if(meta.mixin-exists(hook-modal-close-default-hover)) {@include hook-modal-close-default-hover();}
 }
 
 /*
@@ -279,16 +282,16 @@
     right: (-$modal-close-padding);
     transform: translate(0, -($modal-close-outside-translate));
     color: $modal-close-outside-color;
-    @if(mixin-exists(hook-modal-close-outside)) {@include hook-modal-close-outside();}
+    @if(meta.mixin-exists(hook-modal-close-outside)) {@include hook-modal-close-outside();}
 }
 
 .uk-modal-close-outside:hover {
     color: $modal-close-outside-hover-color;
-    @if(mixin-exists(hook-modal-close-outside-hover)) {@include hook-modal-close-outside-hover();}
+    @if(meta.mixin-exists(hook-modal-close-outside-hover)) {@include hook-modal-close-outside-hover();}
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     /* 1 */
     .uk-modal-close-outside {
@@ -303,18 +306,18 @@
  */
 
 .uk-modal-close-full {
-    @if(mixin-exists(hook-modal-close-full)) {@include hook-modal-close-full();}
+    @if(meta.mixin-exists(hook-modal-close-full)) {@include hook-modal-close-full();}
 }
 
 .uk-modal-close-full:hover {
-    @if(mixin-exists(hook-modal-close-full-hover)) {@include hook-modal-close-full-hover();}
+    @if(meta.mixin-exists(hook-modal-close-full-hover)) {@include hook-modal-close-full-hover();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-modal-misc)) {@include hook-modal-misc();}
+@if(meta.mixin-exists(hook-modal-misc)) {@include hook-modal-misc();}
 
 // @mixin hook-modal(){}
 // @mixin hook-modal-dialog(){}

--- a/src/scss/components/nav.scss
+++ b/src/scss/components/nav.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Nav
 // Description:     Defines styles for list navigations
 //
@@ -100,7 +103,7 @@ $nav-xlarge-font-size-l:                         8rem !default; // 128px
 
 ul.uk-nav-sub {
     padding: $nav-sublist-padding-vertical 0 $nav-sublist-padding-vertical $nav-sublist-padding-left;
-    @if(mixin-exists(hook-nav-sub)) {@include hook-nav-sub();}
+    @if(meta.mixin-exists(hook-nav-sub)) {@include hook-nav-sub();}
 }
 
 /*
@@ -134,7 +137,7 @@ ul.uk-nav-sub {
     padding: $nav-header-padding-vertical $nav-header-padding-horizontal;
     text-transform: $nav-header-text-transform;
     font-size: $nav-header-font-size;
-    @if(mixin-exists(hook-nav-header)) {@include hook-nav-header();}
+    @if(meta.mixin-exists(hook-nav-header)) {@include hook-nav-header();}
 }
 
 .uk-nav-header:not(:first-child) { margin-top: $nav-header-margin-top; }
@@ -145,7 +148,7 @@ ul.uk-nav-sub {
 
 .uk-nav .uk-nav-divider {
     margin: $nav-divider-margin-vertical $nav-divider-margin-horizontal;
-    @if(mixin-exists(hook-nav-divider)) {@include hook-nav-divider();}
+    @if(meta.mixin-exists(hook-nav-divider)) {@include hook-nav-divider();}
 }
 
 
@@ -155,7 +158,7 @@ ul.uk-nav-sub {
 .uk-nav-default {
     font-size: $nav-default-font-size;
     line-height: $nav-default-line-height;
-    @if(mixin-exists(hook-nav-default)) {@include hook-nav-default();}
+    @if(meta.mixin-exists(hook-nav-default)) {@include hook-nav-default();}
 }
 
 /*
@@ -164,19 +167,19 @@ ul.uk-nav-sub {
 
 .uk-nav-default > li > a {
     color: $nav-default-item-color;
-    @if(mixin-exists(hook-nav-default-item)) {@include hook-nav-default-item();}
+    @if(meta.mixin-exists(hook-nav-default-item)) {@include hook-nav-default-item();}
 }
 
 /* Hover */
 .uk-nav-default > li > a:hover {
     color: $nav-default-item-hover-color;
-    @if(mixin-exists(hook-nav-default-item-hover)) {@include hook-nav-default-item-hover();}
+    @if(meta.mixin-exists(hook-nav-default-item-hover)) {@include hook-nav-default-item-hover();}
 }
 
 /* Active */
 .uk-nav-default > li.uk-active > a {
     color: $nav-default-item-active-color;
-    @if(mixin-exists(hook-nav-default-item-active)) {@include hook-nav-default-item-active();}
+    @if(meta.mixin-exists(hook-nav-default-item-active)) {@include hook-nav-default-item-active();}
 }
 
 /*
@@ -185,7 +188,7 @@ ul.uk-nav-sub {
 
 .uk-nav-default .uk-nav-subtitle {
     font-size: $nav-default-subtitle-font-size;
-    @if(mixin-exists(hook-nav-default-subtitle)) {@include hook-nav-default-subtitle();}
+    @if(meta.mixin-exists(hook-nav-default-subtitle)) {@include hook-nav-default-subtitle();}
 }
 
 /*
@@ -194,7 +197,7 @@ ul.uk-nav-sub {
 
 .uk-nav-default .uk-nav-header {
     color: $nav-default-header-color;
-    @if(mixin-exists(hook-nav-default-header)) {@include hook-nav-default-header();}
+    @if(meta.mixin-exists(hook-nav-default-header)) {@include hook-nav-default-header();}
 }
 
 /*
@@ -203,7 +206,7 @@ ul.uk-nav-sub {
 
 .uk-nav-default .uk-nav-divider {
     border-top: $nav-default-divider-border-width solid $nav-default-divider-border;
-    @if(mixin-exists(hook-nav-default-divider)) {@include hook-nav-default-divider();}
+    @if(meta.mixin-exists(hook-nav-default-divider)) {@include hook-nav-default-divider();}
 }
 
 /*
@@ -228,7 +231,7 @@ ul.uk-nav-sub {
 .uk-nav-primary {
     font-size: $nav-primary-font-size;
     line-height: $nav-primary-line-height;
-    @if(mixin-exists(hook-nav-primary)) {@include hook-nav-primary();}
+    @if(meta.mixin-exists(hook-nav-primary)) {@include hook-nav-primary();}
 }
 
 /*
@@ -237,19 +240,19 @@ ul.uk-nav-sub {
 
 .uk-nav-primary > li > a {
     color: $nav-primary-item-color;
-    @if(mixin-exists(hook-nav-primary-item)) {@include hook-nav-primary-item();}
+    @if(meta.mixin-exists(hook-nav-primary-item)) {@include hook-nav-primary-item();}
 }
 
 /* Hover */
 .uk-nav-primary > li > a:hover {
     color: $nav-primary-item-hover-color;
-    @if(mixin-exists(hook-nav-primary-item-hover)) {@include hook-nav-primary-item-hover();}
+    @if(meta.mixin-exists(hook-nav-primary-item-hover)) {@include hook-nav-primary-item-hover();}
 }
 
 /* Active */
 .uk-nav-primary > li.uk-active > a {
     color: $nav-primary-item-active-color;
-    @if(mixin-exists(hook-nav-primary-item-active)) {@include hook-nav-primary-item-active();}
+    @if(meta.mixin-exists(hook-nav-primary-item-active)) {@include hook-nav-primary-item-active();}
 }
 
 /*
@@ -258,7 +261,7 @@ ul.uk-nav-sub {
 
 .uk-nav-primary .uk-nav-subtitle {
     font-size: $nav-primary-subtitle-font-size;
-    @if(mixin-exists(hook-nav-primary-subtitle)) {@include hook-nav-primary-subtitle();}
+    @if(meta.mixin-exists(hook-nav-primary-subtitle)) {@include hook-nav-primary-subtitle();}
 }
 
 /*
@@ -267,7 +270,7 @@ ul.uk-nav-sub {
 
 .uk-nav-primary .uk-nav-header {
     color: $nav-primary-header-color;
-    @if(mixin-exists(hook-nav-primary-header)) {@include hook-nav-primary-header();}
+    @if(meta.mixin-exists(hook-nav-primary-header)) {@include hook-nav-primary-header();}
 }
 
 /*
@@ -276,7 +279,7 @@ ul.uk-nav-sub {
 
 .uk-nav-primary .uk-nav-divider {
     border-top: $nav-primary-divider-border-width solid $nav-primary-divider-border;
-    @if(mixin-exists(hook-nav-primary-divider)) {@include hook-nav-primary-divider();}
+    @if(meta.mixin-exists(hook-nav-primary-divider)) {@include hook-nav-primary-divider();}
 }
 
 /*
@@ -301,7 +304,7 @@ ul.uk-nav-sub {
 .uk-nav-secondary {
     font-size: $nav-secondary-font-size;
     line-height: $nav-secondary-line-height;
-    @if(mixin-exists(hook-nav-secondary)) {@include hook-nav-secondary();}
+    @if(meta.mixin-exists(hook-nav-secondary)) {@include hook-nav-secondary();}
 }
 
 /*
@@ -311,19 +314,19 @@ ul.uk-nav-sub {
 .uk-nav-secondary > li > a {
 
     color: $nav-secondary-item-color;
-    @if(mixin-exists(hook-nav-secondary-item)) {@include hook-nav-secondary-item();}
+    @if(meta.mixin-exists(hook-nav-secondary-item)) {@include hook-nav-secondary-item();}
 }
 
 /* Hover */
 .uk-nav-secondary > li > a:hover {
     color: $nav-secondary-item-hover-color;
-    @if(mixin-exists(hook-nav-secondary-item-hover)) {@include hook-nav-secondary-item-hover();}
+    @if(meta.mixin-exists(hook-nav-secondary-item-hover)) {@include hook-nav-secondary-item-hover();}
 }
 
 /* Active */
 .uk-nav-secondary > li.uk-active > a {
     color: $nav-secondary-item-active-color;
-    @if(mixin-exists(hook-nav-secondary-item-active)) {@include hook-nav-secondary-item-active();}
+    @if(meta.mixin-exists(hook-nav-secondary-item-active)) {@include hook-nav-secondary-item-active();}
 }
 
 /*
@@ -333,19 +336,19 @@ ul.uk-nav-sub {
 .uk-nav-secondary .uk-nav-subtitle {
     font-size: $nav-secondary-subtitle-font-size;
     color: $nav-secondary-subtitle-color;
-    @if(mixin-exists(hook-nav-secondary-subtitle)) {@include hook-nav-secondary-subtitle();}
+    @if(meta.mixin-exists(hook-nav-secondary-subtitle)) {@include hook-nav-secondary-subtitle();}
 }
 
 /* Hover */
 .uk-nav-secondary > li > a:hover .uk-nav-subtitle {
     color: $nav-secondary-subtitle-hover-color;
-    @if(mixin-exists(hook-nav-secondary-subtitle-hover)) {@include hook-nav-secondary-subtitle-hover();}
+    @if(meta.mixin-exists(hook-nav-secondary-subtitle-hover)) {@include hook-nav-secondary-subtitle-hover();}
 }
 
 /* Active */
 .uk-nav-secondary > li.uk-active > a .uk-nav-subtitle {
     color: $nav-secondary-subtitle-active-color;
-    @if(mixin-exists(hook-nav-secondary-subtitle-active)) {@include hook-nav-secondary-subtitle-active();}
+    @if(meta.mixin-exists(hook-nav-secondary-subtitle-active)) {@include hook-nav-secondary-subtitle-active();}
 }
 
 /*
@@ -354,7 +357,7 @@ ul.uk-nav-sub {
 
 .uk-nav-secondary .uk-nav-header {
     color: $nav-secondary-header-color;
-    @if(mixin-exists(hook-nav-secondary-header)) {@include hook-nav-secondary-header();}
+    @if(meta.mixin-exists(hook-nav-secondary-header)) {@include hook-nav-secondary-header();}
 }
 
 /*
@@ -363,7 +366,7 @@ ul.uk-nav-sub {
 
 .uk-nav-secondary .uk-nav-divider {
     border-top: $nav-secondary-divider-border-width solid $nav-secondary-divider-border;
-    @if(mixin-exists(hook-nav-secondary-divider)) {@include hook-nav-secondary-divider();}
+    @if(meta.mixin-exists(hook-nav-secondary-divider)) {@include hook-nav-secondary-divider();}
 }
 
 /*
@@ -392,23 +395,23 @@ ul.uk-nav-sub {
 .uk-nav-medium {
     font-size: $nav-medium-font-size;
     line-height: $nav-medium-line-height;
-    @if(mixin-exists(hook-nav-medium)) {@include hook-nav-medium();}
+    @if(meta.mixin-exists(hook-nav-medium)) {@include hook-nav-medium();}
 }
 
 .uk-nav-large {
     font-size: $nav-large-font-size;
     line-height: $nav-large-line-height;
-    @if(mixin-exists(hook-nav-large)) {@include hook-nav-large();}
+    @if(meta.mixin-exists(hook-nav-large)) {@include hook-nav-large();}
 }
 
 .uk-nav-xlarge {
     font-size: $nav-xlarge-font-size;
     line-height: $nav-xlarge-line-height;
-    @if(mixin-exists(hook-nav-xlarge)) {@include hook-nav-xlarge();}
+    @if(meta.mixin-exists(hook-nav-xlarge)) {@include hook-nav-xlarge();}
 }
 
 /* Tablet Landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-nav-medium { font-size: $nav-medium-font-size-m; }
     .uk-nav-large { font-size: $nav-large-font-size-m; }
@@ -417,7 +420,7 @@ ul.uk-nav-sub {
 }
 
 /* Laptop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-nav-medium { font-size: $nav-medium-font-size-l; }
     .uk-nav-large { font-size: $nav-large-font-size-l; }
@@ -459,14 +462,14 @@ ul.uk-nav-sub {
     margin-top: $nav-dividers-margin-top;
     padding-top: $nav-dividers-margin-top;
     border-top: $nav-dividers-border-width solid $nav-dividers-border;
-    @if(mixin-exists(hook-nav-dividers)) {@include hook-nav-dividers();}
+    @if(meta.mixin-exists(hook-nav-dividers)) {@include hook-nav-dividers();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-nav-misc)) {@include hook-nav-misc();}
+@if(meta.mixin-exists(hook-nav-misc)) {@include hook-nav-misc();}
 
 // @mixin hook-nav-sub(){}
 // @mixin hook-nav-header(){}

--- a/src/scss/components/navbar.scss
+++ b/src/scss/components/navbar.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Navbar
 // Description:     Component to create horizontal navigation bars
 //
@@ -61,7 +65,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
     display: flex;
     /* 1 */
     position: relative;
-    @if(mixin-exists(hook-navbar)) {@include hook-navbar();}
+    @if(meta.mixin-exists(hook-navbar)) {@include hook-navbar();}
 }
 
 
@@ -70,7 +74,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-container:not(.uk-navbar-transparent) {
     background: $navbar-background;
-    @if(mixin-exists(hook-navbar-container)) {@include hook-navbar-container();}
+    @if(meta.mixin-exists(hook-navbar-container)) {@include hook-navbar-container();}
 }
 
 // Color Mode
@@ -131,8 +135,8 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
    top: 0;
 }
 
-.uk-navbar-center-left { right: unquote('calc(100% + #{$navbar-gap})'); }
-.uk-navbar-center-right { left: unquote('calc(100% + #{$navbar-gap})'); }
+.uk-navbar-center-left { right: string.unquote('calc(100% + #{$navbar-gap})'); }
+.uk-navbar-center-right { left: string.unquote('calc(100% + #{$navbar-gap})'); }
 
 [class*="uk-navbar-center-"] {
     width: max-content;
@@ -200,7 +204,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 .uk-navbar-nav > li > a {
     padding: 0 $navbar-nav-item-padding-horizontal;
     color: $navbar-nav-item-color;
-    @if(mixin-exists(hook-navbar-nav-item)) {@include hook-navbar-nav-item();}
+    @if(meta.mixin-exists(hook-navbar-nav-item)) {@include hook-navbar-nav-item();}
 }
 
 /*
@@ -211,19 +215,19 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 .uk-navbar-nav > li:hover > a,
 .uk-navbar-nav > li > a[aria-expanded="true"] {
     color: $navbar-nav-item-hover-color;
-    @if(mixin-exists(hook-navbar-nav-item-hover)) {@include hook-navbar-nav-item-hover();}
+    @if(meta.mixin-exists(hook-navbar-nav-item-hover)) {@include hook-navbar-nav-item-hover();}
 }
 
 /* OnClick */
 .uk-navbar-nav > li > a:active {
     color: $navbar-nav-item-onclick-color;
-    @if(mixin-exists(hook-navbar-nav-item-onclick)) {@include hook-navbar-nav-item-onclick();}
+    @if(meta.mixin-exists(hook-navbar-nav-item-onclick)) {@include hook-navbar-nav-item-onclick();}
 }
 
 /* Active */
 .uk-navbar-nav > li.uk-active > a {
     color: $navbar-nav-item-active-color;
-    @if(mixin-exists(hook-navbar-nav-item-active)) {@include hook-navbar-nav-item-active();}
+    @if(meta.mixin-exists(hook-navbar-nav-item-active)) {@include hook-navbar-nav-item-active();}
 }
 
 
@@ -244,7 +248,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 .uk-navbar-item {
     padding: 0 $navbar-item-padding-horizontal;
     color: $navbar-item-color;
-    @if(mixin-exists(hook-navbar-item)) {@include hook-navbar-item();}
+    @if(meta.mixin-exists(hook-navbar-item)) {@include hook-navbar-item();}
 }
 
 /*
@@ -260,14 +264,14 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 .uk-navbar-toggle {
     padding: 0 $navbar-item-padding-horizontal;
     color: $navbar-toggle-color;
-    @if(mixin-exists(hook-navbar-toggle)) {@include hook-navbar-toggle();}
+    @if(meta.mixin-exists(hook-navbar-toggle)) {@include hook-navbar-toggle();}
 }
 
 .uk-navbar-toggle:hover,
 .uk-navbar-toggle[aria-expanded="true"] {
     color: $navbar-toggle-hover-color;
     text-decoration: none;
-    @if(mixin-exists(hook-navbar-toggle-hover)) {@include hook-navbar-toggle-hover();}
+    @if(meta.mixin-exists(hook-navbar-toggle-hover)) {@include hook-navbar-toggle-hover();}
 }
 
 /*
@@ -276,12 +280,12 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
  */
 
 .uk-navbar-toggle-icon {
-    @if(mixin-exists(hook-navbar-toggle-icon)) {@include hook-navbar-toggle-icon();}
+    @if(meta.mixin-exists(hook-navbar-toggle-icon)) {@include hook-navbar-toggle-icon();}
 }
 
 /* Hover */
 :hover > .uk-navbar-toggle-icon {
-    @if(mixin-exists(hook-navbar-toggle-icon-hover)) {@include hook-navbar-toggle-icon-hover();}
+    @if(meta.mixin-exists(hook-navbar-toggle-icon-hover)) {@include hook-navbar-toggle-icon-hover();}
 }
 
 
@@ -290,7 +294,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-subtitle {
     font-size: $navbar-subtitle-font-size;
-    @if(mixin-exists(hook-navbar-subtitle)) {@include hook-navbar-subtitle();}
+    @if(meta.mixin-exists(hook-navbar-subtitle)) {@include hook-navbar-subtitle();}
 }
 
 
@@ -309,15 +313,15 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
  ========================================================================== */
 
 .uk-navbar-primary {
-    @if(mixin-exists(hook-navbar-primary)) {@include hook-navbar-primary();}
+    @if(meta.mixin-exists(hook-navbar-primary)) {@include hook-navbar-primary();}
 }
 
 .uk-navbar-transparent {
-    @if(mixin-exists(hook-navbar-transparent)) {@include hook-navbar-transparent();}
+    @if(meta.mixin-exists(hook-navbar-transparent)) {@include hook-navbar-transparent();}
 }
 
 .uk-navbar-sticky {
-    @if(mixin-exists(hook-navbar-sticky)) {@include hook-navbar-sticky();}
+    @if(meta.mixin-exists(hook-navbar-sticky)) {@include hook-navbar-sticky();}
 }
 
 
@@ -341,7 +345,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
     padding: $navbar-dropdown-padding;
     background: $navbar-dropdown-background;
     color: $navbar-dropdown-color;
-    @if(mixin-exists(hook-navbar-dropdown)) {@include hook-navbar-dropdown();}
+    @if(meta.mixin-exists(hook-navbar-dropdown)) {@include hook-navbar-dropdown();}
 }
 
 /*
@@ -388,7 +392,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 .uk-navbar-dropdown-large {
     --uk-position-shift-offset: #{$navbar-dropdown-large-shift-margin};
     padding: $navbar-dropdown-large-padding;
-    @if(mixin-exists(hook-navbar-dropdown-large)) {@include hook-navbar-dropdown-large();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-large)) {@include hook-navbar-dropdown-large();}
 }
 
 /*
@@ -408,18 +412,18 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
     --uk-position-offset: #{$navbar-dropdown-dropbar-margin};
     --uk-position-shift-offset: #{$navbar-dropdown-dropbar-shift-margin};
     --uk-position-viewport-offset: #{$navbar-dropdown-dropbar-viewport-margin};
-    @if(mixin-exists(hook-navbar-dropdown-dropbar)) {@include hook-navbar-dropdown-dropbar();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-dropbar)) {@include hook-navbar-dropdown-dropbar();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-navbar-dropdown-dropbar { --uk-position-viewport-offset: #{$navbar-dropdown-dropbar-viewport-margin-s}; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-navbar-dropdown-dropbar { --uk-position-viewport-offset: #{$navbar-dropdown-dropbar-viewport-margin-m}; }
 
@@ -429,7 +433,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
     --uk-position-shift-offset: #{$navbar-dropdown-dropbar-large-shift-margin};
     padding-top: $navbar-dropdown-dropbar-large-padding-top;
     padding-bottom: $navbar-dropdown-dropbar-large-padding-bottom;
-    @if(mixin-exists(hook-navbar-dropdown-dropbar-large)) {@include hook-navbar-dropdown-dropbar-large();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-dropbar-large)) {@include hook-navbar-dropdown-dropbar-large();}
 }
 
 
@@ -438,7 +442,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
  ========================================================================== */
 
 .uk-navbar-dropdown-nav {
-    @if(mixin-exists(hook-navbar-dropdown-nav)) {@include hook-navbar-dropdown-nav();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav)) {@include hook-navbar-dropdown-nav();}
 }
 
 /*
@@ -447,19 +451,19 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-dropdown-nav > li > a {
     color: $navbar-dropdown-nav-item-color;
-    @if(mixin-exists(hook-navbar-dropdown-nav-item)) {@include hook-navbar-dropdown-nav-item();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-item)) {@include hook-navbar-dropdown-nav-item();}
 }
 
 /* Hover */
 .uk-navbar-dropdown-nav > li > a:hover {
     color: $navbar-dropdown-nav-item-hover-color;
-    @if(mixin-exists(hook-navbar-dropdown-nav-item-hover)) {@include hook-navbar-dropdown-nav-item-hover();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-item-hover)) {@include hook-navbar-dropdown-nav-item-hover();}
 }
 
 /* Active */
 .uk-navbar-dropdown-nav > li.uk-active > a {
     color: $navbar-dropdown-nav-item-active-color;
-    @if(mixin-exists(hook-navbar-dropdown-nav-item-active)) {@include hook-navbar-dropdown-nav-item-active();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-item-active)) {@include hook-navbar-dropdown-nav-item-active();}
 }
 
 /*
@@ -468,7 +472,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-dropdown-nav .uk-nav-subtitle {
     font-size: $navbar-dropdown-nav-subtitle-font-size;
-    @if(mixin-exists(hook-navbar-dropdown-nav-subtitle)) {@include hook-navbar-dropdown-nav-subtitle();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-subtitle)) {@include hook-navbar-dropdown-nav-subtitle();}
 }
 
 /*
@@ -477,7 +481,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-dropdown-nav .uk-nav-header {
     color: $navbar-dropdown-nav-header-color;
-    @if(mixin-exists(hook-navbar-dropdown-nav-header)) {@include hook-navbar-dropdown-nav-header();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-header)) {@include hook-navbar-dropdown-nav-header();}
 }
 
 /*
@@ -486,7 +490,7 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
 
 .uk-navbar-dropdown-nav .uk-nav-divider {
     border-top: $navbar-dropdown-nav-divider-border-width solid $navbar-dropdown-nav-divider-border;
-    @if(mixin-exists(hook-navbar-dropdown-nav-divider)) {@include hook-navbar-dropdown-nav-divider();}
+    @if(meta.mixin-exists(hook-navbar-dropdown-nav-divider)) {@include hook-navbar-dropdown-nav-divider();}
 }
 
 /*
@@ -508,14 +512,14 @@ $navbar-nav-gap:                                 0px !default; // Must have a un
  */
 
 .uk-navbar-dropbar {
-    @if(mixin-exists(hook-navbar-dropbar)) {@include hook-navbar-dropbar();}
+    @if(meta.mixin-exists(hook-navbar-dropbar)) {@include hook-navbar-dropbar();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-navbar-misc)) {@include hook-navbar-misc();}
+@if(meta.mixin-exists(hook-navbar-misc)) {@include hook-navbar-misc();}
 
 // @mixin hook-navbar(){}
 // @mixin hook-navbar-container(){}

--- a/src/scss/components/notification.scss
+++ b/src/scss/components/notification.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Notification
 // Description:     Component to create notification messages
 //
@@ -46,7 +47,7 @@
     /* 2 */
     box-sizing: border-box;
     width: $notification-width;
-    @if(mixin-exists(hook-notification)) {@include hook-notification();}
+    @if(meta.mixin-exists(hook-notification)) {@include hook-notification();}
 }
 
 
@@ -100,7 +101,7 @@
     font-size: $notification-message-font-size;
     line-height: $notification-message-line-height;
     cursor: pointer;
-    @if(mixin-exists(hook-notification-message)) {@include hook-notification-message();}
+    @if(meta.mixin-exists(hook-notification-message)) {@include hook-notification-message();}
 }
 
 * + .uk-notification-message { margin-top: $notification-message-margin-top; }
@@ -115,7 +116,7 @@
     position: absolute;
     top: $notification-close-top;
     right: $notification-close-right;
-    @if(mixin-exists(hook-notification-close)) {@include hook-notification-close();}
+    @if(meta.mixin-exists(hook-notification-close)) {@include hook-notification-close();}
 }
 
 .uk-notification-message:hover .uk-notification-close { display: block; }
@@ -130,7 +131,7 @@
 
 .uk-notification-message-primary {
     color: $notification-message-primary-color;
-    @if(mixin-exists(hook-notification-message-primary)) {@include hook-notification-message-primary();}
+    @if(meta.mixin-exists(hook-notification-message-primary)) {@include hook-notification-message-primary();}
 }
 
 /*
@@ -139,7 +140,7 @@
 
 .uk-notification-message-success {
     color: $notification-message-success-color;
-    @if(mixin-exists(hook-notification-message-success)) {@include hook-notification-message-success();}
+    @if(meta.mixin-exists(hook-notification-message-success)) {@include hook-notification-message-success();}
 }
 
 /*
@@ -148,7 +149,7 @@
 
 .uk-notification-message-warning {
     color: $notification-message-warning-color;
-    @if(mixin-exists(hook-notification-message-warning)) {@include hook-notification-message-warning();}
+    @if(meta.mixin-exists(hook-notification-message-warning)) {@include hook-notification-message-warning();}
 }
 
 /*
@@ -157,14 +158,14 @@
 
 .uk-notification-message-danger {
     color: $notification-message-danger-color;
-    @if(mixin-exists(hook-notification-message-danger)) {@include hook-notification-message-danger();}
+    @if(meta.mixin-exists(hook-notification-message-danger)) {@include hook-notification-message-danger();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-notification-misc)) {@include hook-notification-misc();}
+@if(meta.mixin-exists(hook-notification-misc)) {@include hook-notification-misc();}
 
 // @mixin hook-notification(){}
 // @mixin hook-notification-message(){}

--- a/src/scss/components/offcanvas.scss
+++ b/src/scss/components/offcanvas.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Off-canvas
 // Description:     Component to create an off-canvas sidebar
 //
@@ -83,11 +86,11 @@
     background: $offcanvas-bar-background;
     /* 3 */
     overflow-y: auto;
-    @if(mixin-exists(hook-offcanvas-bar)) {@include hook-offcanvas-bar();}
+    @if(meta.mixin-exists(hook-offcanvas-bar)) {@include hook-offcanvas-bar();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-offcanvas-bar {
         left: (-$offcanvas-bar-width-s);
@@ -108,7 +111,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-offcanvas-flip .uk-offcanvas-bar { right: (-$offcanvas-bar-width-s); }
 
@@ -166,7 +169,7 @@
 .uk-open > .uk-offcanvas-reveal { width: $offcanvas-bar-width; }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-open > .uk-offcanvas-reveal { width: $offcanvas-bar-width-s; }
 
@@ -192,11 +195,11 @@
     top: $offcanvas-close-position;
     right: $offcanvas-close-position;
     padding: $offcanvas-close-padding;
-    @if(mixin-exists(hook-offcanvas-close)) {@include hook-offcanvas-close();}
+    @if(meta.mixin-exists(hook-offcanvas-close)) {@include hook-offcanvas-close();}
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-offcanvas-close {
         top: $offcanvas-close-position-s;
@@ -245,7 +248,7 @@
     /* 2 */
     opacity: 0;
     transition: opacity 0.15s linear;
-    @if(mixin-exists(hook-offcanvas-overlay)) {@include hook-offcanvas-overlay();}
+    @if(meta.mixin-exists(hook-offcanvas-overlay)) {@include hook-offcanvas-overlay();}
 }
 
 .uk-offcanvas-overlay.uk-open::before { opacity: 1; }
@@ -296,7 +299,7 @@
 .uk-offcanvas-flip.uk-offcanvas-container-animation { left: (-$offcanvas-bar-width); }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     :not(.uk-offcanvas-flip).uk-offcanvas-container-animation { left: $offcanvas-bar-width-s; }
 
@@ -308,7 +311,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-offcanvas-misc)) {@include hook-offcanvas-misc();}
+@if(meta.mixin-exists(hook-offcanvas-misc)) {@include hook-offcanvas-misc();}
 
 // @mixin hook-offcanvas-bar(){}
 // @mixin hook-offcanvas-close(){}

--- a/src/scss/components/overlay.scss
+++ b/src/scss/components/overlay.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Overlay
 // Description:     Component to create content areas overlaying an image
 //
@@ -24,7 +25,7 @@
 
 .uk-overlay {
     padding: $overlay-padding-vertical $overlay-padding-horizontal;
-    @if(mixin-exists(hook-overlay)) {@include hook-overlay();}
+    @if(meta.mixin-exists(hook-overlay)) {@include hook-overlay();}
 }
 
 /*
@@ -38,7 +39,7 @@
  ========================================================================== */
 
 .uk-overlay-icon {
-    @if(mixin-exists(hook-overlay-icon)) {@include hook-overlay-icon();}
+    @if(meta.mixin-exists(hook-overlay-icon)) {@include hook-overlay-icon();}
 }
 
 
@@ -52,7 +53,7 @@
 .uk-overlay-default {
     --uk-inverse: #{$overlay-default-color-mode};
     background: $overlay-default-background;
-    @if(mixin-exists(hook-overlay-default)) {@include hook-overlay-default();}
+    @if(meta.mixin-exists(hook-overlay-default)) {@include hook-overlay-default();}
 }
 
 // Color Mode
@@ -66,7 +67,7 @@
 .uk-overlay-primary {
     --uk-inverse: #{$overlay-primary-color-mode};
     background: $overlay-primary-background;
-    @if(mixin-exists(hook-overlay-primary)) {@include hook-overlay-primary();}
+    @if(meta.mixin-exists(hook-overlay-primary)) {@include hook-overlay-primary();}
 }
 
 // Color Mode
@@ -77,7 +78,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-overlay-misc)) {@include hook-overlay-misc();}
+@if(meta.mixin-exists(hook-overlay-misc)) {@include hook-overlay-misc();}
 
 // @mixin hook-overlay(){}
 // @mixin hook-overlay-icon(){}

--- a/src/scss/components/padding.scss
+++ b/src/scss/components/padding.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Padding
 // Description:     Utilities for padding
 //
@@ -22,7 +25,7 @@
 .uk-padding { padding: $padding-padding; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-padding { padding: $padding-padding-l; }
 
@@ -41,7 +44,7 @@
 .uk-padding-large { padding: $padding-large-padding; }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-padding-large { padding: $padding-large-padding-l; }
 
@@ -71,6 +74,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-padding-misc)) {@include hook-padding-misc();}
+@if(meta.mixin-exists(hook-padding-misc)) {@include hook-padding-misc();}
 
 // @mixin hook-padding-misc(){}

--- a/src/scss/components/pagination.scss
+++ b/src/scss/components/pagination.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Pagination
 // Description:     Component to create a page navigation
 //
@@ -40,7 +41,7 @@
     /* 4 */
     padding: 0;
     list-style: none;
-    @if(mixin-exists(hook-pagination)) {@include hook-pagination();}
+    @if(meta.mixin-exists(hook-pagination)) {@include hook-pagination();}
 }
 
 /*
@@ -77,33 +78,33 @@
     /* 3 */
     padding: $pagination-item-padding-vertical $pagination-item-padding-horizontal;
     color: $pagination-item-color;
-    @if(mixin-exists(hook-pagination-item)) {@include hook-pagination-item();}
+    @if(meta.mixin-exists(hook-pagination-item)) {@include hook-pagination-item();}
 }
 
 /* Hover */
 .uk-pagination > * > :hover {
     color: $pagination-item-hover-color;
     text-decoration: $pagination-item-hover-text-decoration;
-    @if(mixin-exists(hook-pagination-item-hover)) {@include hook-pagination-item-hover();}
+    @if(meta.mixin-exists(hook-pagination-item-hover)) {@include hook-pagination-item-hover();}
 }
 
 /* Active */
 .uk-pagination > .uk-active > * {
     color: $pagination-item-active-color;
-    @if(mixin-exists(hook-pagination-item-active)) {@include hook-pagination-item-active();}
+    @if(meta.mixin-exists(hook-pagination-item-active)) {@include hook-pagination-item-active();}
 }
 
 /* Disabled */
 .uk-pagination > .uk-disabled > * {
     color: $pagination-item-disabled-color;
-    @if(mixin-exists(hook-pagination-item-disabled)) {@include hook-pagination-item-disabled();}
+    @if(meta.mixin-exists(hook-pagination-item-disabled)) {@include hook-pagination-item-disabled();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-pagination-misc)) {@include hook-pagination-misc();}
+@if(meta.mixin-exists(hook-pagination-misc)) {@include hook-pagination-misc();}
 
 // @mixin hook-pagination(){}
 // @mixin hook-pagination-item(){}

--- a/src/scss/components/placeholder.scss
+++ b/src/scss/components/placeholder.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Placeholder
 // Description:     Component to create placeholder boxes
 //
@@ -19,7 +20,7 @@
     margin-bottom: $placeholder-margin-vertical;
     padding: $placeholder-padding-vertical $placeholder-padding-horizontal;
     background: $placeholder-background;
-    @if(mixin-exists(hook-placeholder)) {@include hook-placeholder();}
+    @if(meta.mixin-exists(hook-placeholder)) {@include hook-placeholder();}
 }
 
 /* Add margin if adjacent element */
@@ -35,7 +36,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-placeholder-misc)) {@include hook-placeholder-misc();}
+@if(meta.mixin-exists(hook-placeholder-misc)) {@include hook-placeholder-misc();}
 
 // @mixin hook-placeholder(){}
 // @mixin hook-placeholder-misc(){}

--- a/src/scss/components/position.scss
+++ b/src/scss/components/position.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Position
 // Description:     Utilities to position content
 //
@@ -52,7 +56,7 @@
 [class*="uk-position-center"] {
     position: absolute !important;
     /* 1 */
-    max-width: unquote('calc(100% - (var(--uk-position-margin-offset) * 2))');
+    max-width: string.unquote('calc(100% - (var(--uk-position-margin-offset) * 2))');
     box-sizing: border-box;
 }
 
@@ -116,8 +120,8 @@
  */
 
 .uk-position-center {
-    top: unquote('calc(50% - var(--uk-position-margin-offset))');
-    left: unquote('calc(50% - var(--uk-position-margin-offset))');
+    top: string.unquote('calc(50% - var(--uk-position-margin-offset))');
+    left: string.unquote('calc(50% - var(--uk-position-margin-offset))');
     --uk-position-translate-x: -50%;
     --uk-position-translate-y: -50%;
     transform: translate(var(--uk-position-translate-x), var(--uk-position-translate-y));
@@ -129,7 +133,7 @@
 [class*="uk-position-center-left"],
 [class*="uk-position-center-right"],
 .uk-position-center-vertical {
-    top: unquote('calc(50% - var(--uk-position-margin-offset))');
+    top: string.unquote('calc(50% - var(--uk-position-margin-offset))');
     --uk-position-translate-y: -50%;
     transform: translate(0, var(--uk-position-translate-y));
 }
@@ -155,7 +159,7 @@
 .uk-position-top-center,
 .uk-position-bottom-center,
 .uk-position-center-horizontal {
-    left: unquote('calc(50% - var(--uk-position-margin-offset))');
+    left: string.unquote('calc(50% - var(--uk-position-margin-offset))');
     --uk-position-translate-x: -50%;
     transform: translate(var(--uk-position-translate-x), 0);
     /* 1 */
@@ -201,7 +205,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-position-large {
         margin: $position-large-margin-l;
@@ -232,6 +236,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-position-misc)) {@include hook-position-misc();}
+@if(meta.mixin-exists(hook-position-misc)) {@include hook-position-misc();}
 
 // @mixin hook-position-misc(){}

--- a/src/scss/components/print.scss
+++ b/src/scss/components/print.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Print
 // Description:     Optimize page for printing
 //
@@ -51,7 +52,7 @@
     h2,
     h3 { page-break-after: avoid; }
 
-   @if(mixin-exists(hook-print)) {@include hook-print();}
+   @if(meta.mixin-exists(hook-print)) {@include hook-print();}
 
 }
 

--- a/src/scss/components/progress.scss
+++ b/src/scss/components/progress.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Progress
 // Description:     Component to create progress bars
 //
@@ -37,7 +38,7 @@
     /* 5 */
     margin-bottom: $progress-margin-vertical;
     height: $progress-height;
-    @if(mixin-exists(hook-progress)) {@include hook-progress();}
+    @if(meta.mixin-exists(hook-progress)) {@include hook-progress();}
 }
 
 /* Add margin if adjacent element */
@@ -58,21 +59,21 @@
 .uk-progress::-webkit-progress-value {
     background-color: $progress-bar-background;
     transition: width 0.6s ease;
-    @if(mixin-exists(hook-progress-bar)) {@include hook-progress-bar();}
+    @if(meta.mixin-exists(hook-progress-bar)) {@include hook-progress-bar();}
 }
 
 .uk-progress::-moz-progress-bar {
     background-color: $progress-bar-background;
     /* 1 */
     transition: width 0.6s ease;
-    @if(mixin-exists(hook-progress-bar)) {@include hook-progress-bar();}
+    @if(meta.mixin-exists(hook-progress-bar)) {@include hook-progress-bar();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-progress-misc)) {@include hook-progress-misc();}
+@if(meta.mixin-exists(hook-progress-misc)) {@include hook-progress-misc();}
 
 // @mixin hook-progress(){}
 // @mixin hook-progress-bar(){}

--- a/src/scss/components/search.scss
+++ b/src/scss/components/search.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Search
 // Description:     Component to create the search
 //
@@ -102,7 +103,7 @@
     /* 9 */
     border: none;
     color: $search-color;
-    @if(mixin-exists(hook-search-input)) {@include hook-search-input();}
+    @if(meta.mixin-exists(hook-search-input)) {@include hook-search-input();}
 }
 
 .uk-search-input:focus { outline: none; }
@@ -133,7 +134,7 @@
     align-items: center;
     /* 3 */
     color: $search-icon-color;
-    @if(mixin-exists(hook-search-icon)) {@include hook-search-icon();}
+    @if(meta.mixin-exists(hook-search-icon)) {@include hook-search-icon();}
 }
 
 /*
@@ -172,13 +173,13 @@
     padding-left: $search-default-padding-horizontal;
     padding-right: $search-default-padding-horizontal;
     background: $search-default-background;
-    @if(mixin-exists(hook-search-default-input)) {@include hook-search-default-input();}
+    @if(meta.mixin-exists(hook-search-default-input)) {@include hook-search-default-input();}
 }
 
 /* Focus */
 .uk-search-default .uk-search-input:focus {
     background-color: $search-default-focus-background;
-    @if(mixin-exists(hook-search-default-input-focus)) {@include hook-search-default-input-focus();}
+    @if(meta.mixin-exists(hook-search-default-input-focus)) {@include hook-search-default-input-focus();}
 }
 
 /*
@@ -208,13 +209,13 @@
     padding-left: $search-navbar-padding-horizontal;
     padding-right: $search-navbar-padding-horizontal;
     background: $search-navbar-background;
-    @if(mixin-exists(hook-search-navbar-input)) {@include hook-search-navbar-input();}
+    @if(meta.mixin-exists(hook-search-navbar-input)) {@include hook-search-navbar-input();}
 }
 
 /* Focus */
 .uk-search-navbar .uk-search-input:focus {
     background-color: $search-navbar-focus-background;
-    @if(mixin-exists(hook-search-navbar-input-focus)) {@include hook-search-navbar-input-focus();}
+    @if(meta.mixin-exists(hook-search-navbar-input-focus)) {@include hook-search-navbar-input-focus();}
 }
 
 /*
@@ -245,13 +246,13 @@
     padding-right: $search-medium-padding-horizontal;
     background: $search-medium-background;
     font-size: $search-medium-font-size;
-    @if(mixin-exists(hook-search-medium-input)) {@include hook-search-medium-input();}
+    @if(meta.mixin-exists(hook-search-medium-input)) {@include hook-search-medium-input();}
 }
 
 /* Focus */
 .uk-search-medium .uk-search-input:focus {
     background-color: $search-medium-focus-background;
-    @if(mixin-exists(hook-search-medium-input-focus)) {@include hook-search-medium-input-focus();}
+    @if(meta.mixin-exists(hook-search-medium-input-focus)) {@include hook-search-medium-input-focus();}
 }
 
 /*
@@ -282,13 +283,13 @@
     padding-right: $search-large-padding-horizontal;
     background: $search-large-background;
     font-size: $search-large-font-size;
-    @if(mixin-exists(hook-search-large-input)) {@include hook-search-large-input();}
+    @if(meta.mixin-exists(hook-search-large-input)) {@include hook-search-large-input();}
 }
 
 /* Focus */
 .uk-search-large .uk-search-input:focus {
     background-color: $search-medium-focus-background;
-    @if(mixin-exists(hook-search-large-input-focus)) {@include hook-search-large-input-focus();}
+    @if(meta.mixin-exists(hook-search-large-input-focus)) {@include hook-search-large-input-focus();}
 }
 
 /*
@@ -309,20 +310,20 @@
 
 .uk-search-toggle {
     color: $search-toggle-color;
-    @if(mixin-exists(hook-search-toggle)) {@include hook-search-toggle();}
+    @if(meta.mixin-exists(hook-search-toggle)) {@include hook-search-toggle();}
 }
 
 /* Hover */
 .uk-search-toggle:hover {
     color: $search-toggle-hover-color;
-    @if(mixin-exists(hook-search-toggle-hover)) {@include hook-search-toggle-hover();}
+    @if(meta.mixin-exists(hook-search-toggle-hover)) {@include hook-search-toggle-hover();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-search-misc)) {@include hook-search-misc();}
+@if(meta.mixin-exists(hook-search-misc)) {@include hook-search-misc();}
 
 // @mixin hook-search-input(){}
 // @mixin hook-search-icon(){}

--- a/src/scss/components/section.scss
+++ b/src/scss/components/section.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Section
 // Description:     Component to create horizontal layout section
 //
@@ -44,11 +47,11 @@
     box-sizing: border-box; /* 1 */
     padding-top: $section-padding-vertical;
     padding-bottom: $section-padding-vertical;
-    @if(mixin-exists(hook-section)) {@include hook-section();}
+    @if(meta.mixin-exists(hook-section)) {@include hook-section();}
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-section {
         padding-top: $section-padding-vertical-m;
@@ -95,7 +98,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-section-large {
         padding-top: $section-large-padding-vertical-m;
@@ -114,7 +117,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-section-xlarge {
         padding-top: $section-xlarge-padding-vertical-m;
@@ -134,7 +137,7 @@
 .uk-section-default {
     --uk-inverse: #{$section-default-color-mode};
     background: $section-default-background;
-    @if(mixin-exists(hook-section-default)) {@include hook-section-default();}
+    @if(meta.mixin-exists(hook-section-default)) {@include hook-section-default();}
 }
 
 @if ( $section-default-color-mode == light ) { .uk-section-default:not(.uk-preserve-color) { @extend .uk-light !optional;} }
@@ -147,7 +150,7 @@
 .uk-section-muted {
     --uk-inverse: #{$section-muted-color-mode};
     background: $section-muted-background;
-    @if(mixin-exists(hook-section-muted)) {@include hook-section-muted();}
+    @if(meta.mixin-exists(hook-section-muted)) {@include hook-section-muted();}
 }
 
 @if ( $section-muted-color-mode == light ) { .uk-section-muted:not(.uk-preserve-color) { @extend .uk-light !optional;} }
@@ -161,7 +164,7 @@
 .uk-section-primary {
     --uk-inverse: #{$section-primary-color-mode};
     background: $section-primary-background;
-    @if(mixin-exists(hook-section-primary)) {@include hook-section-primary();}
+    @if(meta.mixin-exists(hook-section-primary)) {@include hook-section-primary();}
 }
 
 @if ( $section-primary-color-mode == light ) { .uk-section-primary:not(.uk-preserve-color) { @extend .uk-light !optional;} }
@@ -174,7 +177,7 @@
 .uk-section-secondary {
     --uk-inverse: #{$section-secondary-color-mode};
     background: $section-secondary-background;
-    @if(mixin-exists(hook-section-secondary)) {@include hook-section-secondary();}
+    @if(meta.mixin-exists(hook-section-secondary)) {@include hook-section-secondary();}
 }
 
 @if ( $section-secondary-color-mode == light ) { .uk-section-secondary:not(.uk-preserve-color) { @extend .uk-light !optional;} }
@@ -190,14 +193,14 @@
  */
 
 .uk-section-overlap {
-    @if(mixin-exists(hook-section-overlap)) {@include hook-section-overlap();}
+    @if(meta.mixin-exists(hook-section-overlap)) {@include hook-section-overlap();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-section-misc)) {@include hook-section-misc();}
+@if(meta.mixin-exists(hook-section-misc)) {@include hook-section-misc();}
 
 // @mixin hook-section(){}
 // @mixin hook-section-default(){}

--- a/src/scss/components/slidenav.scss
+++ b/src/scss/components/slidenav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Slidenav
 // Description:     Component to create previous/next icon navigations
 //
@@ -30,19 +31,19 @@
 .uk-slidenav {
     padding: $slidenav-padding-vertical $slidenav-padding-horizontal;
     color: $slidenav-color;
-    @if(mixin-exists(hook-slidenav)) {@include hook-slidenav();}
+    @if(meta.mixin-exists(hook-slidenav)) {@include hook-slidenav();}
 }
 
 /* Hover */
 .uk-slidenav:hover {
     color: $slidenav-hover-color;
-    @if(mixin-exists(hook-slidenav-hover)) {@include hook-slidenav-hover();}
+    @if(meta.mixin-exists(hook-slidenav-hover)) {@include hook-slidenav-hover();}
 }
 
 /* OnClick */
 .uk-slidenav:active {
     color: $slidenav-active-color;
-    @if(mixin-exists(hook-slidenav-active)) {@include hook-slidenav-active();}
+    @if(meta.mixin-exists(hook-slidenav-active)) {@include hook-slidenav-active();}
 }
 
 
@@ -54,7 +55,7 @@
  */
 
 .uk-slidenav-previous {
-    @if(mixin-exists(hook-slidenav-previous)) {@include hook-slidenav-previous();}
+    @if(meta.mixin-exists(hook-slidenav-previous)) {@include hook-slidenav-previous();}
 }
 
 /*
@@ -62,7 +63,7 @@
  */
 
 .uk-slidenav-next {
-    @if(mixin-exists(hook-slidenav-next)) {@include hook-slidenav-next();}
+    @if(meta.mixin-exists(hook-slidenav-next)) {@include hook-slidenav-next();}
 }
 
 
@@ -71,7 +72,7 @@
 
 .uk-slidenav-large {
     padding: $slidenav-large-padding-vertical $slidenav-large-padding-horizontal;
-    @if(mixin-exists(hook-slidenav-large)) {@include hook-slidenav-large();}
+    @if(meta.mixin-exists(hook-slidenav-large)) {@include hook-slidenav-large();}
 }
 
 
@@ -80,14 +81,14 @@
 
 .uk-slidenav-container {
     display: flex;
-    @if(mixin-exists(hook-slidenav-container)) {@include hook-slidenav-container();}
+    @if(meta.mixin-exists(hook-slidenav-container)) {@include hook-slidenav-container();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-slidenav-misc)) {@include hook-slidenav-misc();}
+@if(meta.mixin-exists(hook-slidenav-misc)) {@include hook-slidenav-misc();}
 
 // @mixin hook-slidenav(){}
 // @mixin hook-slidenav-hover(){}

--- a/src/scss/components/slider.scss
+++ b/src/scss/components/slider.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Slider
 // Description:     Component to create horizontal sliders
 //
@@ -27,7 +28,7 @@
 .uk-slider {
     /* 1 */
     -webkit-tap-highlight-color: transparent;
-    @if(mixin-exists(hook-slider)) {@include hook-slider();}
+    @if(meta.mixin-exists(hook-slider)) {@include hook-slider();}
 }
 
 
@@ -113,7 +114,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-slider-misc)) {@include hook-slider-misc();}
+@if(meta.mixin-exists(hook-slider-misc)) {@include hook-slider-misc();}
 
 // @mixin hook-slider(){}
 // @mixin hook-slider-misc(){}

--- a/src/scss/components/slideshow.scss
+++ b/src/scss/components/slideshow.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Slideshow
 // Description:     Component to create slideshows
 //
@@ -21,7 +22,7 @@
 .uk-slideshow {
     /* 1 */
     -webkit-tap-highlight-color: transparent;
-    @if(mixin-exists(hook-slideshow)) {@include hook-slideshow();}
+    @if(meta.mixin-exists(hook-slideshow)) {@include hook-slideshow();}
 }
 
 
@@ -87,7 +88,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-slideshow-misc)) {@include hook-slideshow-misc();}
+@if(meta.mixin-exists(hook-slideshow-misc)) {@include hook-slideshow-misc();}
 
 // @mixin hook-slideshow(){}
 // @mixin hook-slideshow-misc(){}

--- a/src/scss/components/sortable.scss
+++ b/src/scss/components/sortable.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Sortable
 // Description:     Component to create sortable grids and lists
 //
@@ -27,7 +28,7 @@
 
 .uk-sortable {
     position: relative;
-    @if(mixin-exists(hook-sortable)) {@include hook-sortable();}
+    @if(meta.mixin-exists(hook-sortable)) {@include hook-sortable();}
 }
 
 /*
@@ -44,7 +45,7 @@
     position: fixed !important;
     z-index: $sortable-dragged-z-index !important;
     pointer-events: none;
-    @if(mixin-exists(hook-sortable-drag)) {@include hook-sortable-drag();}
+    @if(meta.mixin-exists(hook-sortable-drag)) {@include hook-sortable-drag();}
 }
 
 
@@ -54,7 +55,7 @@
 .uk-sortable-placeholder {
     opacity: $sortable-placeholder-opacity;
     pointer-events: none;
-    @if(mixin-exists(hook-sortable-placeholder)) {@include hook-sortable-placeholder();}
+    @if(meta.mixin-exists(hook-sortable-placeholder)) {@include hook-sortable-placeholder();}
 }
 
 
@@ -63,7 +64,7 @@
 
 .uk-sortable-empty {
     min-height: $sortable-empty-height;
-    @if(mixin-exists(hook-sortable-empty)) {@include hook-sortable-empty();}
+    @if(meta.mixin-exists(hook-sortable-empty)) {@include hook-sortable-empty();}
 }
 
 
@@ -78,7 +79,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-sortable-misc)) {@include hook-sortable-misc();}
+@if(meta.mixin-exists(hook-sortable-misc)) {@include hook-sortable-misc();}
 
 // @mixin hook-sortable(){}
 // @mixin hook-sortable-drag(){}

--- a/src/scss/components/spinner.scss
+++ b/src/scss/components/spinner.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+@use "sass:meta";
 // Name:            Spinner
 // Description:     Component to create a loading spinner
 //
@@ -9,7 +11,7 @@
 // Variables
 // ========================================================================
 
-$spinner-radius:                                 floor((($spinner-size - $spinner-stroke-width) * 0.5)) !default; // Minus stroke width to prevent overflow clipping
+$spinner-radius:                                 math.floor((($spinner-size - $spinner-stroke-width) * 0.5)) !default; // Minus stroke width to prevent overflow clipping
 
 
 /* ========================================================================
@@ -21,7 +23,7 @@ $spinner-radius:                                 floor((($spinner-size - $spinne
  */
 
 .uk-spinner {
-    @if(mixin-exists(hook-spinner)) {@include hook-spinner();}
+    @if(meta.mixin-exists(hook-spinner)) {@include hook-spinner();}
 }
 
 
@@ -64,7 +66,7 @@ $spinner-radius:                                 floor((($spinner-size - $spinne
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-spinner-misc)) {@include hook-spinner-misc();}
+@if(meta.mixin-exists(hook-spinner-misc)) {@include hook-spinner-misc();}
 
 // @mixin hook-spinner(){}
 // @mixin hook-spinner-misc(){}

--- a/src/scss/components/sticky.scss
+++ b/src/scss/components/sticky.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Sticky
 // Description:     Component to make elements sticky in the viewport
 //
@@ -57,6 +58,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-sticky-misc)) {@include hook-sticky-misc();}
+@if(meta.mixin-exists(hook-sticky-misc)) {@include hook-sticky-misc();}
 
 // @mixin hook-sticky-misc(){}

--- a/src/scss/components/subnav.scss
+++ b/src/scss/components/subnav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Subnav
 // Description:     Component to create a sub navigation
 //
@@ -43,7 +44,7 @@
     /* 4 */
     padding: 0;
     list-style: none;
-    @if(mixin-exists(hook-subnav)) {@include hook-subnav();}
+    @if(meta.mixin-exists(hook-subnav)) {@include hook-subnav();}
 }
 
 /*
@@ -81,20 +82,20 @@
     column-gap: 0.25em;
     /* 3 */
     color: $subnav-item-color;
-    @if(mixin-exists(hook-subnav-item)) {@include hook-subnav-item();}
+    @if(meta.mixin-exists(hook-subnav-item)) {@include hook-subnav-item();}
 }
 
 /* Hover */
 .uk-subnav > * > a:hover {
     color: $subnav-item-hover-color;
     text-decoration: $subnav-item-hover-text-decoration;
-    @if(mixin-exists(hook-subnav-item-hover)) {@include hook-subnav-item-hover();}
+    @if(meta.mixin-exists(hook-subnav-item-hover)) {@include hook-subnav-item-hover();}
 }
 
 /* Active */
 .uk-subnav > .uk-active > a {
     color: $subnav-item-active-color;
-    @if(mixin-exists(hook-subnav-item-active)) {@include hook-subnav-item-active();}
+    @if(meta.mixin-exists(hook-subnav-item-active)) {@include hook-subnav-item-active();}
 }
 
 
@@ -132,7 +133,7 @@
 /* 1 */
 .uk-subnav-divider > :nth-child(n+2):not(.uk-first-column)::before {
     border-left-color: $subnav-divider-border;
-    @if(mixin-exists(hook-subnav-divider)) {@include hook-subnav-divider();}
+    @if(meta.mixin-exists(hook-subnav-divider)) {@include hook-subnav-divider();}
 }
 
 
@@ -150,28 +151,28 @@
     padding: $subnav-pill-item-padding-vertical $subnav-pill-item-padding-horizontal;
     background: $subnav-pill-item-background;
     color: $subnav-pill-item-color;
-    @if(mixin-exists(hook-subnav-pill-item)) {@include hook-subnav-pill-item();}
+    @if(meta.mixin-exists(hook-subnav-pill-item)) {@include hook-subnav-pill-item();}
 }
 
 /* Hover */
 .uk-subnav-pill > * > a:hover {
     background-color: $subnav-pill-item-hover-background;
     color: $subnav-pill-item-hover-color;
-    @if(mixin-exists(hook-subnav-pill-item-hover)) {@include hook-subnav-pill-item-hover();}
+    @if(meta.mixin-exists(hook-subnav-pill-item-hover)) {@include hook-subnav-pill-item-hover();}
 }
 
 /* OnClick */
 .uk-subnav-pill > * > a:active {
     background-color: $subnav-pill-item-onclick-background;
     color: $subnav-pill-item-onclick-color;
-    @if(mixin-exists(hook-subnav-pill-item-onclick)) {@include hook-subnav-pill-item-onclick();}
+    @if(meta.mixin-exists(hook-subnav-pill-item-onclick)) {@include hook-subnav-pill-item-onclick();}
 }
 
 /* Active */
 .uk-subnav-pill > .uk-active > a {
     background-color: $subnav-pill-item-active-background;
     color: $subnav-pill-item-active-color;
-    @if(mixin-exists(hook-subnav-pill-item-active)) {@include hook-subnav-pill-item-active();}
+    @if(meta.mixin-exists(hook-subnav-pill-item-active)) {@include hook-subnav-pill-item-active();}
 }
 
 
@@ -181,14 +182,14 @@
 
 .uk-subnav > .uk-disabled > a {
     color: $subnav-item-disabled-color;
-    @if(mixin-exists(hook-subnav-item-disabled)) {@include hook-subnav-item-disabled();}
+    @if(meta.mixin-exists(hook-subnav-item-disabled)) {@include hook-subnav-item-disabled();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-subnav-misc)) {@include hook-subnav-misc();}
+@if(meta.mixin-exists(hook-subnav-misc)) {@include hook-subnav-misc();}
 
 // @mixin hook-subnav(){}
 // @mixin hook-subnav-item(){}

--- a/src/scss/components/svg.scss
+++ b/src/scss/components/svg.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            SVG
 // Description:     Component to style SVGs
 //
@@ -31,6 +32,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-svg-misc)) {@include hook-svg-misc();}
+@if(meta.mixin-exists(hook-svg-misc)) {@include hook-svg-misc();}
 
 // @mixin hook-svg-misc(){}

--- a/src/scss/components/switcher.scss
+++ b/src/scss/components/switcher.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Switcher
 // Description:     Component to navigate through different content panes
 //
@@ -42,6 +43,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-switcher-misc)) {@include hook-switcher-misc();}
+@if(meta.mixin-exists(hook-switcher-misc)) {@include hook-switcher-misc();}
 
 // @mixin hook-switcher-misc(){}

--- a/src/scss/components/tab.scss
+++ b/src/scss/components/tab.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Tab
 // Description:     Component to create a tabbed navigation
 //
@@ -38,7 +39,7 @@
     /* 3 */
     padding: 0;
     list-style: none;
-    @if(mixin-exists(hook-tab)) {@include hook-tab();}
+    @if(meta.mixin-exists(hook-tab)) {@include hook-tab();}
 }
 
 /*
@@ -79,26 +80,26 @@
     /* 4 */
     padding: $tab-item-padding-vertical $tab-item-padding-horizontal;
     color: $tab-item-color;
-    @if(mixin-exists(hook-tab-item)) {@include hook-tab-item();}
+    @if(meta.mixin-exists(hook-tab-item)) {@include hook-tab-item();}
 }
 
 /* Hover */
 .uk-tab > * > a:hover {
     color: $tab-item-hover-color;
     text-decoration: $tab-item-hover-text-decoration;
-    @if(mixin-exists(hook-tab-item-hover)) {@include hook-tab-item-hover();}
+    @if(meta.mixin-exists(hook-tab-item-hover)) {@include hook-tab-item-hover();}
 }
 
 /* Active */
 .uk-tab > .uk-active > a {
     color: $tab-item-active-color;
-    @if(mixin-exists(hook-tab-item-active)) {@include hook-tab-item-active();}
+    @if(meta.mixin-exists(hook-tab-item-active)) {@include hook-tab-item-active();}
 }
 
 /* Disabled */
 .uk-tab > .uk-disabled > a {
     color: $tab-item-disabled-color;
-    @if(mixin-exists(hook-tab-item-disabled)) {@include hook-tab-item-disabled();}
+    @if(meta.mixin-exists(hook-tab-item-disabled)) {@include hook-tab-item-disabled();}
 }
 
 
@@ -110,11 +111,11 @@
  */
 
 .uk-tab-bottom {
-    @if(mixin-exists(hook-tab-bottom)) {@include hook-tab-bottom();}
+    @if(meta.mixin-exists(hook-tab-bottom)) {@include hook-tab-bottom();}
 }
 
 .uk-tab-bottom > * > a {
-    @if(mixin-exists(hook-tab-bottom-item)) {@include hook-tab-bottom-item();}
+    @if(meta.mixin-exists(hook-tab-bottom-item)) {@include hook-tab-bottom-item();}
 }
 
 /*
@@ -134,28 +135,28 @@
 .uk-tab-right > * { padding-left: 0; }
 
 .uk-tab-left {
-    @if(mixin-exists(hook-tab-left)) {@include hook-tab-left();}
+    @if(meta.mixin-exists(hook-tab-left)) {@include hook-tab-left();}
 }
 
 .uk-tab-right {
-    @if(mixin-exists(hook-tab-right)) {@include hook-tab-right();}
+    @if(meta.mixin-exists(hook-tab-right)) {@include hook-tab-right();}
 }
 
 .uk-tab-left > * > a {
     justify-content: left;
-    @if(mixin-exists(hook-tab-left-item)) {@include hook-tab-left-item();}
+    @if(meta.mixin-exists(hook-tab-left-item)) {@include hook-tab-left-item();}
 }
 
 .uk-tab-right > * > a {
     justify-content: left;
-    @if(mixin-exists(hook-tab-right-item)) {@include hook-tab-right-item();}
+    @if(meta.mixin-exists(hook-tab-right-item)) {@include hook-tab-right-item();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-tab-misc)) {@include hook-tab-misc();}
+@if(meta.mixin-exists(hook-tab-misc)) {@include hook-tab-misc();}
 
 // @mixin hook-tab(){}
 // @mixin hook-tab-item(){}

--- a/src/scss/components/table.scss
+++ b/src/scss/components/table.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+@use "sass:meta";
 // Name:            Table
 // Description:     Styles for tables
 //
@@ -53,7 +55,7 @@
     width: 100%;
     /* 3 */
     margin-bottom: $table-margin-vertical;
-    @if(mixin-exists(hook-table)) {@include hook-table();}
+    @if(meta.mixin-exists(hook-table)) {@include hook-table();}
 }
 
 /* Add margin if adjacent element */
@@ -75,7 +77,7 @@
     font-size: $table-header-cell-font-size;
     font-weight: $table-header-cell-font-weight;
     color: $table-header-cell-color;
-    @if(mixin-exists(hook-table-header-cell)) {@include hook-table-header-cell();}
+    @if(meta.mixin-exists(hook-table-header-cell)) {@include hook-table-header-cell();}
 }
 
 
@@ -85,7 +87,7 @@
 .uk-table td {
     padding: $table-cell-padding-vertical $table-cell-padding-horizontal;
     vertical-align: top;
-    @if(mixin-exists(hook-table-cell)) {@include hook-table-cell();}
+    @if(meta.mixin-exists(hook-table-cell)) {@include hook-table-cell();}
 }
 
 /*
@@ -100,7 +102,7 @@
 
 .uk-table tfoot {
     font-size: $table-footer-font-size;
-    @if(mixin-exists(hook-table-footer)) {@include hook-table-footer();}
+    @if(meta.mixin-exists(hook-table-footer)) {@include hook-table-footer();}
 }
 
 
@@ -111,7 +113,7 @@
     font-size: $table-caption-font-size;
     text-align: left;
     color: $table-caption-color;
-    @if(mixin-exists(hook-table-caption)) {@include hook-table-caption();}
+    @if(meta.mixin-exists(hook-table-caption)) {@include hook-table-caption();}
 }
 
 
@@ -133,7 +135,7 @@
 .uk-table-divider > :not(:first-child) > tr,
 .uk-table-divider > :first-child > tr:not(:first-child) {
     border-top: $table-divider-border-width solid $table-divider-border;
-    @if(mixin-exists(hook-table-divider)) {@include hook-table-divider();}
+    @if(meta.mixin-exists(hook-table-divider)) {@include hook-table-divider();}
 }
 
 /*
@@ -143,7 +145,7 @@
 .uk-table-striped > tr:nth-of-type(odd),
 .uk-table-striped tbody tr:nth-of-type(odd) {
     background: $table-striped-row-background;
-    @if(mixin-exists(hook-table-striped)) {@include hook-table-striped();}
+    @if(meta.mixin-exists(hook-table-striped)) {@include hook-table-striped();}
 }
 
 /*
@@ -153,7 +155,7 @@
 .uk-table-hover > tr:hover,
 .uk-table-hover tbody tr:hover {
     background: $table-hover-row-background;
-    @if(mixin-exists(hook-table-hover)) {@include hook-table-hover();}
+    @if(meta.mixin-exists(hook-table-hover)) {@include hook-table-hover();}
 }
 
 
@@ -163,7 +165,7 @@
 .uk-table > tr.uk-active,
 .uk-table tbody tr.uk-active {
     background: $table-row-active-background;
-    @if(mixin-exists(hook-table-row-active)) {@include hook-table-row-active();}
+    @if(meta.mixin-exists(hook-table-row-active)) {@include hook-table-row-active();}
 }
 
 /* Size modifier
@@ -172,13 +174,13 @@
 .uk-table-small th,
 .uk-table-small td {
     padding: $table-small-cell-padding-vertical $table-small-cell-padding-horizontal;
-    @if(mixin-exists(hook-table-small)) {@include hook-table-small();}
+    @if(meta.mixin-exists(hook-table-small)) {@include hook-table-small();}
 }
 
 .uk-table-large th,
 .uk-table-large td {
     padding: $table-large-cell-padding-vertical $table-large-cell-padding-horizontal;
-    @if(mixin-exists(hook-table-large)) {@include hook-table-large();}
+    @if(meta.mixin-exists(hook-table-large)) {@include hook-table-large();}
 }
 
 
@@ -242,11 +244,11 @@
 
     .uk-table-responsive th:not(:first-child):not(.uk-table-link),
     .uk-table-responsive td:not(:first-child):not(.uk-table-link),
-    .uk-table-responsive .uk-table-link:not(:first-child) > a { padding-top: round(($table-cell-padding-vertical * 0.33333)) !important; }
+    .uk-table-responsive .uk-table-link:not(:first-child) > a { padding-top: math.round(($table-cell-padding-vertical * 0.33333)) !important; }
 
     .uk-table-responsive th:not(:last-child):not(.uk-table-link),
     .uk-table-responsive td:not(:last-child):not(.uk-table-link),
-    .uk-table-responsive .uk-table-link:not(:last-child) > a { padding-bottom: round(($table-cell-padding-vertical * 0.33333)) !important; }
+    .uk-table-responsive .uk-table-link:not(:last-child) > a { padding-bottom: math.round(($table-cell-padding-vertical * 0.33333)) !important; }
 
     .uk-table-justify.uk-table-responsive th,
     .uk-table-justify.uk-table-responsive td {
@@ -260,7 +262,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-table-misc)) {@include hook-table-misc();}
+@if(meta.mixin-exists(hook-table-misc)) {@include hook-table-misc();}
 
 // @mixin hook-table(){}
 // @mixin hook-table-header-cell(){}

--- a/src/scss/components/text.scss
+++ b/src/scss/components/text.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Text
 // Description:     Utilities for text
 //
@@ -29,14 +32,14 @@
     font-size: $text-lead-font-size;
     line-height: $text-lead-line-height;
     color: $text-lead-color;
-    @if(mixin-exists(hook-text-lead)) {@include hook-text-lead();}
+    @if(meta.mixin-exists(hook-text-lead)) {@include hook-text-lead();}
 }
 
 .uk-text-meta {
     font-size: $text-meta-font-size;
     line-height: $text-meta-line-height;
     color: $text-meta-color;
-    @if(mixin-exists(hook-text-meta)) {@include hook-text-meta();}
+    @if(meta.mixin-exists(hook-text-meta)) {@include hook-text-meta();}
 }
 
 
@@ -46,18 +49,18 @@
 .uk-text-small {
     font-size: $text-small-font-size;
     line-height: $text-small-line-height;
-    @if(mixin-exists(hook-text-small)) {@include hook-text-small();}
+    @if(meta.mixin-exists(hook-text-small)) {@include hook-text-small();}
 }
 
 .uk-text-large {
     font-size: $text-large-font-size;
     line-height: $text-large-line-height;
-    @if(mixin-exists(hook-text-large)) {@include hook-text-large();}
+    @if(meta.mixin-exists(hook-text-large)) {@include hook-text-large();}
 }
 
 .uk-text-default {
     font-size: $global-font-size;
-    line-height: $global-line-height;
+    line-height: variables.$global-line-height;
 }
 
 
@@ -123,7 +126,7 @@
     display: inline-block;
     /* 4 */
     background-color: $text-background-color;
-    @if(mixin-exists(hook-text-background)) {@include hook-text-background();}
+    @if(meta.mixin-exists(hook-text-background)) {@include hook-text-background();}
 }
 
 
@@ -136,7 +139,7 @@
 .uk-text-justify { text-align: justify !important; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-text-left\@s { text-align: left !important; }
     .uk-text-right\@s { text-align: right !important; }
@@ -145,7 +148,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-text-left\@m { text-align: left !important; }
     .uk-text-right\@m { text-align: right !important; }
@@ -154,7 +157,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-text-left\@l { text-align: left !important; }
     .uk-text-right\@l { text-align: right !important; }
@@ -163,7 +166,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-text-left\@xl { text-align: left !important; }
     .uk-text-right\@xl { text-align: right !important; }
@@ -234,7 +237,7 @@ td.uk-text-truncate { max-width: 0; }
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-text-misc)) {@include hook-text-misc();}
+@if(meta.mixin-exists(hook-text-misc)) {@include hook-text-misc();}
 
 // @mixin hook-text-lead(){}
 // @mixin hook-text-meta(){}

--- a/src/scss/components/thumbnav.scss
+++ b/src/scss/components/thumbnav.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Thumbnav
 // Description:     Component to create thumbnail navigations
 //
@@ -35,7 +36,7 @@
     list-style: none;
     /* 3 */
     margin-left: (-$thumbnav-margin-horizontal);
-    @if(mixin-exists(hook-thumbnav)) {@include hook-thumbnav();}
+    @if(meta.mixin-exists(hook-thumbnav)) {@include hook-thumbnav();}
 }
 
 /*
@@ -58,17 +59,17 @@
 
 .uk-thumbnav > * > * {
     display: inline-block;
-    @if(mixin-exists(hook-thumbnav-item)) {@include hook-thumbnav-item();}
+    @if(meta.mixin-exists(hook-thumbnav-item)) {@include hook-thumbnav-item();}
 }
 
 /* Hover */
 .uk-thumbnav > * > :hover {
-    @if(mixin-exists(hook-thumbnav-item-hover)) {@include hook-thumbnav-item-hover();}
+    @if(meta.mixin-exists(hook-thumbnav-item-hover)) {@include hook-thumbnav-item-hover();}
 }
 
 /* Active */
 .uk-thumbnav > .uk-active > * {
-    @if(mixin-exists(hook-thumbnav-item-active)) {@include hook-thumbnav-item-active();}
+    @if(meta.mixin-exists(hook-thumbnav-item-active)) {@include hook-thumbnav-item-active();}
 }
 
 
@@ -98,7 +99,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-thumbnav-misc)) {@include hook-thumbnav-misc();}
+@if(meta.mixin-exists(hook-thumbnav-misc)) {@include hook-thumbnav-misc();}
 
 // @mixin hook-thumbnav(){}
 // @mixin hook-thumbnav-item(){}

--- a/src/scss/components/tile.scss
+++ b/src/scss/components/tile.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Tile
 // Description:     Component to create tiled boxes
 //
@@ -42,11 +45,11 @@
     padding-right: $tile-padding-horizontal;
     padding-top: $tile-padding-vertical;
     padding-bottom: $tile-padding-vertical;
-    @if(mixin-exists(hook-tile)) {@include hook-tile();}
+    @if(meta.mixin-exists(hook-tile)) {@include hook-tile();}
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-tile {
         padding-left: $tile-padding-horizontal-s;
@@ -56,7 +59,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-tile {
         padding-left: $tile-padding-horizontal-m;
@@ -105,7 +108,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-tile-large {
         padding-top: $tile-large-padding-vertical-m;
@@ -125,7 +128,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-tile-xlarge {
         padding-top: $tile-xlarge-padding-vertical-m;
@@ -145,11 +148,11 @@
 .uk-tile-default {
     --uk-inverse: #{$tile-default-color-mode};
     background-color: $tile-default-background;
-    @if(mixin-exists(hook-tile-default)) {@include hook-tile-default();}
+    @if(meta.mixin-exists(hook-tile-default)) {@include hook-tile-default();}
 }
 
 .uk-tile-default.uk-tile-hover:hover {
-    @if(mixin-exists(hook-tile-default-hover)) {@include hook-tile-default-hover();}
+    @if(meta.mixin-exists(hook-tile-default-hover)) {@include hook-tile-default-hover();}
 }
 
 // Color Mode
@@ -163,11 +166,11 @@
 .uk-tile-muted {
     --uk-inverse: #{$tile-muted-color-mode};
     background-color: $tile-muted-background;
-    @if(mixin-exists(hook-tile-muted)) {@include hook-tile-muted();}
+    @if(meta.mixin-exists(hook-tile-muted)) {@include hook-tile-muted();}
 }
 
 .uk-tile-muted.uk-tile-hover:hover {
-    @if(mixin-exists(hook-tile-muted-hover)) {@include hook-tile-muted-hover();}
+    @if(meta.mixin-exists(hook-tile-muted-hover)) {@include hook-tile-muted-hover();}
 }
 
 // Color Mode
@@ -181,11 +184,11 @@
 .uk-tile-primary {
     --uk-inverse: #{$tile-primary-color-mode};
     background-color: $tile-primary-background;
-    @if(mixin-exists(hook-tile-primary)) {@include hook-tile-primary();}
+    @if(meta.mixin-exists(hook-tile-primary)) {@include hook-tile-primary();}
 }
 
 .uk-tile-primary.uk-tile-hover:hover {
-    @if(mixin-exists(hook-tile-primary-hover)) {@include hook-tile-primary-hover();}
+    @if(meta.mixin-exists(hook-tile-primary-hover)) {@include hook-tile-primary-hover();}
 }
 
 // Color Mode
@@ -199,11 +202,11 @@
 .uk-tile-secondary {
     --uk-inverse: #{$tile-secondary-color-mode};
     background-color: $tile-secondary-background;
-    @if(mixin-exists(hook-tile-secondary)) {@include hook-tile-secondary();}
+    @if(meta.mixin-exists(hook-tile-secondary)) {@include hook-tile-secondary();}
 }
 
 .uk-tile-secondary.uk-tile-hover:hover {
-    @if(mixin-exists(hook-tile-secondary-hover)) {@include hook-tile-secondary-hover();}
+    @if(meta.mixin-exists(hook-tile-secondary-hover)) {@include hook-tile-secondary-hover();}
 }
 
 // Color Mode
@@ -214,7 +217,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-tile-misc)) {@include hook-tile-misc();}
+@if(meta.mixin-exists(hook-tile-misc)) {@include hook-tile-misc();}
 
 // @mixin hook-tile(){}
 // @mixin hook-tile-default(){}

--- a/src/scss/components/tooltip.scss
+++ b/src/scss/components/tooltip.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Tooltip
 // Description:     Component to create tooltips
 //
@@ -54,7 +55,7 @@
     border-radius: $tooltip-border-radius;
     color: $tooltip-color;
     font-size: $tooltip-font-size;
-    @if(mixin-exists(hook-tooltip)) {@include hook-tooltip();}
+    @if(meta.mixin-exists(hook-tooltip)) {@include hook-tooltip();}
 }
 
 /* Show */
@@ -64,7 +65,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-tooltip-misc)) {@include hook-tooltip-misc();}
+@if(meta.mixin-exists(hook-tooltip-misc)) {@include hook-tooltip-misc();}
 
 // @mixin hook-tooltip(){}
 // @mixin hook-tooltip-misc(){}

--- a/src/scss/components/totop.scss
+++ b/src/scss/components/totop.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Totop
 // Description:     Component to create an icon to scroll back to top
 //
@@ -24,26 +25,26 @@
 .uk-totop {
     padding: $totop-padding;
     color: $totop-color;
-    @if(mixin-exists(hook-totop)) {@include hook-totop();}
+    @if(meta.mixin-exists(hook-totop)) {@include hook-totop();}
 }
 
 /* Hover */
 .uk-totop:hover {
     color: $totop-hover-color;
-    @if(mixin-exists(hook-totop-hover)) {@include hook-totop-hover();}
+    @if(meta.mixin-exists(hook-totop-hover)) {@include hook-totop-hover();}
 }
 
 /* OnClick */
 .uk-totop:active {
     color: $totop-active-color;
-    @if(mixin-exists(hook-totop-active)) {@include hook-totop-active();}
+    @if(meta.mixin-exists(hook-totop-active)) {@include hook-totop-active();}
 }
 
 
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-totop-misc)) {@include hook-totop-misc();}
+@if(meta.mixin-exists(hook-totop-misc)) {@include hook-totop-misc();}
 
 // @mixin hook-totop(){}
 // @mixin hook-totop-hover(){}

--- a/src/scss/components/transition.scss
+++ b/src/scss/components/transition.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Transition
 // Description:     Utilities for transitions
 //
@@ -162,6 +163,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-transition-misc)) {@include hook-transition-misc();}
+@if(meta.mixin-exists(hook-transition-misc)) {@include hook-transition-misc();}
 
 // @mixin hook-transition-misc(){}

--- a/src/scss/components/utility.scss
+++ b/src/scss/components/utility.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 // Name:            Utility
 // Description:     Utilities collection
 //
@@ -70,7 +71,7 @@
     border: $panel-scrollable-border-width solid $panel-scrollable-border;
     overflow: auto;
     resize: both;
-    @if(mixin-exists(hook-panel-scrollable)) {@include hook-panel-scrollable();}
+    @if(meta.mixin-exists(hook-panel-scrollable)) {@include hook-panel-scrollable();}
 }
 
 
@@ -329,7 +330,7 @@
         filter: blur($box-shadow-bottom-blur);
         /* 3 */
         will-change: filter;
-        @if(mixin-exists(hook-box-shadow-bottom)) {@include hook-box-shadow-bottom();}
+        @if(meta.mixin-exists(hook-box-shadow-bottom)) {@include hook-box-shadow-bottom();}
     }
 
 }
@@ -353,7 +354,7 @@
     float: left;
     font-size: $dropcap-font-size;
     line-height: $dropcap-line-height;
-    @if(mixin-exists(hook-dropcap)) {@include hook-dropcap();}
+    @if(meta.mixin-exists(hook-dropcap)) {@include hook-dropcap();}
 }
 
 /* 2 */
@@ -381,7 +382,7 @@
     color: $logo-color;
     /* 2 */
     text-decoration: none;
-    @if(mixin-exists(hook-logo)) {@include hook-logo();}
+    @if(meta.mixin-exists(hook-logo)) {@include hook-logo();}
 }
 
 /* 3 */
@@ -395,7 +396,7 @@
     color: $logo-hover-color;
     /* 1 */
     text-decoration: none;
-    @if(mixin-exists(hook-logo-hover)) {@include hook-logo-hover();}
+    @if(meta.mixin-exists(hook-logo-hover)) {@include hook-logo-hover();}
 }
 
 .uk-logo :where(img, svg, video) { display: block; }
@@ -477,7 +478,7 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-utility-misc)) {@include hook-utility-misc();}
+@if(meta.mixin-exists(hook-utility-misc)) {@include hook-utility-misc();}
 
 // @mixin hook-panel-scrollable(){}
 // @mixin hook-box-shadow-bottom(){}

--- a/src/scss/components/visibility.scss
+++ b/src/scss/components/visibility.scss
@@ -1,3 +1,6 @@
+@use "sass:meta";
+@use "variables";
+
 // Name:            Visibility
 // Description:     Utilities to show or hide content on breakpoints, hover or touch
 //
@@ -28,28 +31,28 @@
 .uk-hidden-empty:empty { display: none !important; }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-hidden\@s { display: none !important; }
 
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-hidden\@m { display: none !important; }
 
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-hidden\@l { display: none !important; }
 
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-hidden\@xl { display: none !important; }
 
@@ -159,6 +162,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-visibility-misc)) {@include hook-visibility-misc();}
+@if(meta.mixin-exists(hook-visibility-misc)) {@include hook-visibility-misc();}
 
 // @mixin hook-visibility-misc(){}

--- a/src/scss/components/width.scss
+++ b/src/scss/components/width.scss
@@ -1,3 +1,7 @@
+@use "sass:meta";
+@use "sass:string";
+@use "variables";
+
 // Name:            Width
 // Description:     Utilities for widths
 //
@@ -26,10 +30,10 @@
 }
 
 .uk-child-width-1-2 > * { width: 50%; }
-.uk-child-width-1-3 > * { width: unquote('calc(100% / 3)'); }
+.uk-child-width-1-3 > * { width: string.unquote('calc(100% / 3)'); }
 .uk-child-width-1-4 > * { width: 25%; }
 .uk-child-width-1-5 > * { width: 20%; }
-.uk-child-width-1-6 > * { width: unquote('calc(100% / 6)'); }
+.uk-child-width-1-6 > * { width: string.unquote('calc(100% / 6)'); }
 
 .uk-child-width-auto > * { width: auto; }
 
@@ -47,14 +51,14 @@
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     .uk-child-width-1-1\@s > * { width: 100%; }
     .uk-child-width-1-2\@s > * { width: 50%; }
-    .uk-child-width-1-3\@s > * { width: unquote('calc(100% / 3)'); }
+    .uk-child-width-1-3\@s > * { width: string.unquote('calc(100% / 3)'); }
     .uk-child-width-1-4\@s > * { width: 25%; }
     .uk-child-width-1-5\@s > * { width: 20%; }
-    .uk-child-width-1-6\@s > * { width: unquote('calc(100% / 6)'); }
+    .uk-child-width-1-6\@s > * { width: string.unquote('calc(100% / 6)'); }
 
     .uk-child-width-auto\@s > * { width: auto; }
     .uk-child-width-expand\@s > :not([class*="uk-width"]) {
@@ -74,14 +78,14 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     .uk-child-width-1-1\@m > * { width: 100%; }
     .uk-child-width-1-2\@m > * { width: 50%; }
-    .uk-child-width-1-3\@m > * { width: unquote('calc(100% / 3)'); }
+    .uk-child-width-1-3\@m > * { width: string.unquote('calc(100% / 3)'); }
     .uk-child-width-1-4\@m > * { width: 25%; }
     .uk-child-width-1-5\@m > * { width: 20%; }
-    .uk-child-width-1-6\@m > * { width: unquote('calc(100% / 6)'); }
+    .uk-child-width-1-6\@m > * { width: string.unquote('calc(100% / 6)'); }
 
     .uk-child-width-auto\@m > * { width: auto; }
     .uk-child-width-expand\@m > :not([class*="uk-width"]) {
@@ -101,14 +105,14 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     .uk-child-width-1-1\@l > * { width: 100%; }
     .uk-child-width-1-2\@l > * { width: 50%; }
-    .uk-child-width-1-3\@l > * { width: unquote('calc(100% / 3)'); }
+    .uk-child-width-1-3\@l > * { width: string.unquote('calc(100% / 3)'); }
     .uk-child-width-1-4\@l > * { width: 25%; }
     .uk-child-width-1-5\@l > * { width: 20%; }
-    .uk-child-width-1-6\@l > * { width: unquote('calc(100% / 6)'); }
+    .uk-child-width-1-6\@l > * { width: string.unquote('calc(100% / 6)'); }
 
     .uk-child-width-auto\@l > * { width: auto; }
     .uk-child-width-expand\@l > :not([class*="uk-width"]) {
@@ -128,14 +132,14 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     .uk-child-width-1-1\@xl > * { width: 100%; }
     .uk-child-width-1-2\@xl > * { width: 50%; }
-    .uk-child-width-1-3\@xl > * { width: unquote('calc(100% / 3)'); }
+    .uk-child-width-1-3\@xl > * { width: string.unquote('calc(100% / 3)'); }
     .uk-child-width-1-4\@xl > * { width: 25%; }
     .uk-child-width-1-5\@xl > * { width: 20%; }
-    .uk-child-width-1-6\@xl > * { width: unquote('calc(100% / 6)'); }
+    .uk-child-width-1-6\@xl > * { width: string.unquote('calc(100% / 6)'); }
 
     .uk-child-width-auto\@xl > * { width: auto; }
     .uk-child-width-expand\@xl > :not([class*="uk-width"]) {
@@ -173,8 +177,8 @@
 .uk-width-1-2 { width: 50%; }
 
 /* Thirds */
-.uk-width-1-3 { width: unquote('calc(100% / 3)'); }
-.uk-width-2-3 { width: unquote('calc(200% / 3)'); }
+.uk-width-1-3 { width: string.unquote('calc(100% / 3)'); }
+.uk-width-2-3 { width: string.unquote('calc(200% / 3)'); }
 
 /* Quarters */
 .uk-width-1-4 { width: 25%; }
@@ -187,8 +191,8 @@
 .uk-width-4-5 { width: 80%; }
 
 /* Sixths */
-.uk-width-1-6 { width: unquote('calc(100% / 6)'); }
-.uk-width-5-6 { width: unquote('calc(500% / 6)'); }
+.uk-width-1-6 { width: string.unquote('calc(100% / 6)'); }
+.uk-width-5-6 { width: string.unquote('calc(500% / 6)'); }
 
 /* Pixel */
 .uk-width-small { width: $width-small-width; }
@@ -210,7 +214,7 @@
 }
 
 /* Phone landscape and bigger */
-@media (min-width: $breakpoint-small) {
+@media (min-width: variables.$breakpoint-small) {
 
     /* Whole */
     .uk-width-1-1\@s { width: 100%; }
@@ -219,8 +223,8 @@
     .uk-width-1-2\@s { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@s { width: unquote('calc(100% / 3)'); }
-    .uk-width-2-3\@s { width: unquote('calc(200% / 3)'); }
+    .uk-width-1-3\@s { width: string.unquote('calc(100% / 3)'); }
+    .uk-width-2-3\@s { width: string.unquote('calc(200% / 3)'); }
 
     /* Quarters */
     .uk-width-1-4\@s { width: 25%; }
@@ -233,8 +237,8 @@
     .uk-width-4-5\@s { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@s { width: unquote('calc(100% / 6)'); }
-    .uk-width-5-6\@s { width: unquote('calc(500% / 6)'); }
+    .uk-width-1-6\@s { width: string.unquote('calc(100% / 6)'); }
+    .uk-width-5-6\@s { width: string.unquote('calc(500% / 6)'); }
 
     /* Pixel */
     .uk-width-small\@s { width: $width-small-width; }
@@ -278,7 +282,7 @@
 }
 
 /* Tablet landscape and bigger */
-@media (min-width: $breakpoint-medium) {
+@media (min-width: variables.$breakpoint-medium) {
 
     /* Whole */
     .uk-width-1-1\@m { width: 100%; }
@@ -287,8 +291,8 @@
     .uk-width-1-2\@m { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@m { width: unquote('calc(100% / 3)'); }
-    .uk-width-2-3\@m { width: unquote('calc(200% / 3)'); }
+    .uk-width-1-3\@m { width: string.unquote('calc(100% / 3)'); }
+    .uk-width-2-3\@m { width: string.unquote('calc(200% / 3)'); }
 
     /* Quarters */
     .uk-width-1-4\@m { width: 25%; }
@@ -301,8 +305,8 @@
     .uk-width-4-5\@m { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@m { width: unquote('calc(100% / 6)'); }
-    .uk-width-5-6\@m { width: unquote('calc(500% / 6)'); }
+    .uk-width-1-6\@m { width: string.unquote('calc(100% / 6)'); }
+    .uk-width-5-6\@m { width: string.unquote('calc(500% / 6)'); }
 
     /* Pixel */
     .uk-width-small\@m { width: $width-small-width; }
@@ -346,7 +350,7 @@
 }
 
 /* Desktop and bigger */
-@media (min-width: $breakpoint-large) {
+@media (min-width: variables.$breakpoint-large) {
 
     /* Whole */
     .uk-width-1-1\@l { width: 100%; }
@@ -355,8 +359,8 @@
     .uk-width-1-2\@l { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@l { width: unquote('calc(100% / 3)'); }
-    .uk-width-2-3\@l { width: unquote('calc(200% / 3)'); }
+    .uk-width-1-3\@l { width: string.unquote('calc(100% / 3)'); }
+    .uk-width-2-3\@l { width: string.unquote('calc(200% / 3)'); }
 
     /* Quarters */
     .uk-width-1-4\@l { width: 25%; }
@@ -369,8 +373,8 @@
     .uk-width-4-5\@l { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@l { width: unquote('calc(100% / 6)'); }
-    .uk-width-5-6\@l { width: unquote('calc(500% / 6)'); }
+    .uk-width-1-6\@l { width: string.unquote('calc(100% / 6)'); }
+    .uk-width-5-6\@l { width: string.unquote('calc(500% / 6)'); }
 
     /* Pixel */
     .uk-width-small\@l { width: $width-small-width; }
@@ -414,7 +418,7 @@
 }
 
 /* Large screen and bigger */
-@media (min-width: $breakpoint-xlarge) {
+@media (min-width: variables.$breakpoint-xlarge) {
 
     /* Whole */
     .uk-width-1-1\@xl { width: 100%; }
@@ -423,8 +427,8 @@
     .uk-width-1-2\@xl { width: 50%; }
 
     /* Thirds */
-    .uk-width-1-3\@xl { width: unquote('calc(100% / 3)'); }
-    .uk-width-2-3\@xl { width: unquote('calc(200% / 3)'); }
+    .uk-width-1-3\@xl { width: string.unquote('calc(100% / 3)'); }
+    .uk-width-2-3\@xl { width: string.unquote('calc(200% / 3)'); }
 
     /* Quarters */
     .uk-width-1-4\@xl { width: 25%; }
@@ -437,8 +441,8 @@
     .uk-width-4-5\@xl { width: 80%; }
 
     /* Sixths */
-    .uk-width-1-6\@xl { width: unquote('calc(100% / 6)'); }
-    .uk-width-5-6\@xl { width: unquote('calc(500% / 6)'); }
+    .uk-width-1-6\@xl { width: string.unquote('calc(100% / 6)'); }
+    .uk-width-5-6\@xl { width: string.unquote('calc(500% / 6)'); }
 
     /* Pixel */
     .uk-width-small\@xl { width: $width-small-width; }
@@ -492,6 +496,6 @@
 // Hooks
 // ========================================================================
 
-@if(mixin-exists(hook-width-misc)) {@include hook-width-misc();}
+@if(meta.mixin-exists(hook-width-misc)) {@include hook-width-misc();}
 
 // @mixin hook-width-misc(){}

--- a/src/scss/uikit.scss
+++ b/src/scss/uikit.scss
@@ -2,4 +2,4 @@
 // Core
 //
 
-@import "components/_import.scss";
+@use "components/_import.scss";


### PR DESCRIPTION
Originally, Sass used @import rules to load other files with a single global namespace, with all built-in functions also available globally. We’re deprecating both Sass @import rules and global built-in functions now that the module system (@use and @forward rules) has been available for several years.

@import causes numerous problems, requiring Sass members to be manually namespaced to avoid conflicts, slowing down compilation when the same file is imported more than once, and making it very difficult for both humans and tools to tell where a given variable, mixin, or function comes from.

The module system fixes these problems and brings Sass’s modularity up to par with the best practices of other modern languages, but we can’t get the full benefits of it while @import remains in the language.

@import is now deprecated as of Dart Sass 1.80.0. Additionally, we’re also deprecating the global versions of Sass built-in functions that are available in sass: modules.

Refference : [https://sass-lang.com/documentation/breaking-changes/import/](https://sass-lang.com/documentation/breaking-changes/import/)