### PR TITLE
fix(modal, dropdown): ensure modal overlays dropdown by adjusting z-index

### DIFF
--- a/src/less/components/drop.less
+++ b/src/less/components/drop.less
@@ -18,7 +18,7 @@
 // Variables
 // ========================================================================
 
-@drop-z-index:                              @global-z-index + 20;
+@drop-z-index:                              @global-z-index + 10;
 @drop-margin:                               @global-margin;
 @drop-viewport-margin:                      15px;
 @drop-width:                                300px;

--- a/src/less/components/modal.less
+++ b/src/less/components/modal.less
@@ -26,7 +26,7 @@
 // Variables
 // ========================================================================
 
-@modal-z-index:                                 @global-z-index + 10;
+@modal-z-index:                                 @global-z-index + 20;
 @modal-background:                              rgba(0,0,0,0.6);
 
 @modal-padding-horizontal:                      15px;

--- a/src/scss/variables-theme.scss
+++ b/src/scss/variables-theme.scss
@@ -366,7 +366,7 @@ $inverse-dotnav-item-hover-background: rgba($inverse-global-color, 0.9) !default
 $inverse-dotnav-item-onclick-background: rgba($inverse-global-color, 0.5) !default;
 $inverse-dotnav-item-active-background: rgba($inverse-global-color, 0.9) !default;
 $global-z-index: 1000 !default;
-$drop-z-index: $global-z-index + 20 !default;
+$drop-z-index: $global-z-index + 10 !default;
 $drop-margin: $global-margin !default;
 $drop-viewport-margin: 15px !default;
 $drop-width: 300px !default;
@@ -669,7 +669,7 @@ $marker-hover-color: $global-inverse-color !default;
 $inverse-marker-background: $global-muted-background !default;
 $inverse-marker-color: $global-color !default;
 $inverse-marker-hover-color: $global-color !default;
-$modal-z-index: $global-z-index + 10 !default;
+$modal-z-index: $global-z-index + 20 !default;
 $modal-background: rgba(0,0,0,0.6) !default;
 $modal-padding-horizontal: 15px !default;
 $modal-padding-horizontal-s: $global-gutter !default;


### PR DESCRIPTION
Fixes #5133

This PR adjusts the z-index of modal and dropdown components to ensure that modals always appear above dropdowns. The issue occurred when clicking on a dropdown link that opened a modal — the dropdown remained visually above the modal.

Changes:
- Increased modal z-index in both SCSS and LESS files
- Verified layout on modern browsers

Let me know if you'd prefer a different approach!