### PR TITLE
fix/5158: SVG doesn't support base64 data URLs

### DIFF
--- a/src/js/core/svg.js
+++ b/src/js/core/svg.js
@@ -93,7 +93,7 @@ function applyAttributes(el) {
 
 const loadSVG = memoize(async (src) => {
     if (src) {
-        if (startsWith(src, 'data:')) {
+        if (startsWith(src, 'data:') && !includes(src, ";base64")) {
             return decodeURIComponent(src.split(',', 2)[1]);
         } else {
             const response = await fetch(src);


### PR DESCRIPTION
Resolves #5158 

In the `memoize` function in `src/core/js/svg.js`:
- Add a second check to test if the data-url contains the text "base64". Only return the decoded URI component if it's a data-url *and* it's not Base-64
- Base-64 encoded data-urls are treated like any other URL and are `fetch`ed to obtain the text. This saves having to use `atob`, etc

If there is concern about performance, I'm happy to alter it so there is a 3rd decision branch that would use `atob` to decode the SVG data.