### PR TITLE
fix(icon): center plus-circle and minus-circle icons

### DIFF
--- a/src/images/icons/minus-circle.svg
+++ b/src/images/icons/minus-circle.svg
@@ -1,4 +1,4 @@
 <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-    <circle fill="none" stroke="#000" stroke-width="1.1" cx="9.5" cy="9.5" r="9" />
-    <line fill="none" stroke="#000" x1="5" y1="9.5" x2="14" y2="9.5" />
+    <circle fill="none" stroke="#000" stroke-width="1.1" cx="10" cy="10" r="9" />
+    <line fill="none" stroke="#000" x1="5.5" y1="10" x2="14.5" y2="10" />
 </svg>

--- a/src/images/icons/plus-circle.svg
+++ b/src/images/icons/plus-circle.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-    <circle fill="none" stroke="#000" stroke-width="1.1" cx="9.5" cy="9.5" r="9" />
-    <line fill="none" stroke="#000" x1="9.5" y1="5" x2="9.5" y2="14" />
-    <line fill="none" stroke="#000" x1="5" y1="9.5" x2="14" y2="9.5" />
+    <circle fill="none" stroke="#000" stroke-width="1.1" cx="10" cy="10" r="9" />
+    <line fill="none" stroke="#000" x1="10" y1="5.5" x2="10" y2="14.5" />
+    <line fill="none" stroke="#000" x1="5.5" y1="10" x2="14.5" y2="10" />
 </svg>


### PR DESCRIPTION
**What does this PR do?**

This pull request fixes a subtle misalignment in the `plus-circle.svg` and `minus-circle.svg` icons.

Both icons had slight visual offset due to their <circle> element being centered at (9.5, 9.5) rather than (10, 10). This caused extra space on the right and bottom sides when used inside components like `.uk-icon-button`, making them appear off-center compared to other icons.

**What was changed?**
- Adjusted the cx and cy of the main <circle> to (10, 10)
- Updated associated <line> elements to remain visually centered
- Verified the changes using a grid of uk-icon-button elements

**Why is this needed?**

Consistent visual alignment is critical for icon-based UIs, especially when using buttons like:
```
<a class="uk-icon-button" uk-icon="plus-circle"></a>
<a class="uk-icon-button" uk-icon="minus-circle"></a>
```

Before this change, those buttons looked misaligned next to others due to uneven internal spacing in the SVGs.

**How to test**
1. Place `plus-circle`, `minus-circle`, `ban` and `close-circle` in a row using `.uk-icon-button`
2. Observe that `plus-circle` and `minus-circle` are now properly centered, just like the others.

**Visual comparison**

**Before vs After:** This comparison highlights how the original icons had visual offset (right and bottom), which was resolved by centering the shapes inside the SVG canvas:
<img width="747" alt="Screenshot 2025-06-19 at 20 58 03" src="https://github.com/user-attachments/assets/d05a25d5-8943-441a-8e8f-446b07c17901" />
