### PR TITLE
Fix incorrect defaults in Sortable options table

### DIFF
--- a/tests/sortable.html
+++ b/tests/sortable.html
@@ -227,13 +227,13 @@
                         <tr>
                             <td><code>duration</code></td>
                             <td>Number</td>
-                            <td>250</td>
+                            <td>150</td>
                             <td>Animation duration in milliseconds.</td>
                         </tr>
                         <tr>
                             <td><code>threshold</code></td>
                             <td>Number</td>
-                            <td>10</td>
+                            <td>5</td>
                             <td>Mouse move threshold before dragging starts.</td>
                         </tr>
                         <tr>
@@ -257,8 +257,8 @@
                         <tr>
                             <td><code>cls-drag-state</code></td>
                             <td>String</td>
-                            <td>uk-sortable-dragging</td>
-                            <td>The body's dragging class.</td>
+                            <td>uk-drag</td>
+                            <td>The dragging class added to the root element.</td>
                         </tr>
                         <tr>
                             <td><code>cls-base</code></td>


### PR DESCRIPTION
## What

Corrects three default values in the **JavaScript Options** table in `tests/sortable.html` that did not match the component source.

| Option | Documented | Actual | Source |
|---|---|---|---|
| `duration` | 250 | **150** | `src/js/mixin/animate.js` |
| `threshold` | 10 | **5** | `src/js/components/sortable.js` |
| `cls-drag-state` | `uk-sortable-dragging` | **`uk-drag`** | `src/js/components/sortable.js` |

## Why

The defaults in the options table were out of sync with the actual component defaults, which is misleading for anyone using the table as a reference.

I also clarified the `cls-drag-state` description: the class is added to the root element (`document.documentElement`), not the body — see `sortable.js` (`addClass(document.documentElement, this.clsDragState)`).

No functional/source changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)